### PR TITLE
Lower required cmake version to 3.25

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.26)
+cmake_minimum_required(VERSION 3.25)
 
 set(PROJECT_LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
We are not using any feature that needs 3.26.

We could probably lower it more, but I'm chosing 3.25 because that's what Debian stable currently ships.