### PR TITLE
[ATSPI] Add NodeJS bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,15 @@
 For swig:
 * `sudo apt install swig`
 
+For NodeJS module (optional):
+
+* `sudo apt install node-gyp`
+
 #### Build steps
 ```
 % mkdir build
 % cd build
-% cmake .. --fresh
+% cmake <feature-flags> .. --fresh
 % make
 ```
 
@@ -33,6 +37,22 @@ As well as a python module.
 >>> node.accessible_get_name()
 'Google Chrome'
 ```
+
+An optionally a NodeJS module `atspi_inspect.node`.
+```
+% cd build/lib/atspi/
+% nodejs
+> const atspi_inspect = require("./atspi_inspect");
+> let node = atspi_inspect.find_root_accessible_from_pid(<pid>);
+> node.accessible_get_role_name();
+'application'
+> node.accessible_get_name();
+'Chromium'
+```
+
+#### Feature flags
+
+* NodeJS bindings: `-DATSPI_NODEJS_MODULE=<ON/OFF>`, ON by default.
 
 ### On Mac
 

--- a/lib/atspi/CMakeLists.txt
+++ b/lib/atspi/CMakeLists.txt
@@ -1,3 +1,10 @@
+# Feature flag for NodeJS bindings
+option(
+  ATSPI_NODEJS_MODULE
+  "Build NodeJS bindings (requires swig and node-gyp)"
+  ON
+)
+
 add_library(
   # Name
   atspi_inspect
@@ -90,3 +97,48 @@ set_property(
   PROPERTY
     SWIG_USE_TARGET_INCLUDE_DIRECTORIES TRUE
 )
+
+# Generate a NodeJS Module using swig + node-gyp
+
+if (ATSPI_NODEJS_MODULE)
+  find_program(
+    NODE_GYP "node-gyp"
+    REQUIRED
+  )
+
+  ## Final cmake target and proper destination for the NodeJS module
+  add_custom_target(
+    atspi_inspect.node ALL
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/build/Release/atspi_inspect.node"
+    COMMAND cp "./build/Release/atspi_inspect.node" .
+  )
+
+  set_property(
+    TARGET atspi_inspect.node
+    APPEND
+    PROPERTY ADDITIONAL_CLEAN_FILES
+      binding.gyp
+      ${CMAKE_CURRENT_BINARY_DIR}/build
+      atspi_inspect.node
+  )
+
+  ## Generate `binding.gyp` file for node-gyp
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/binding.gyp.in binding.gyp
+  )
+
+  ## Generate C++ wrapper for NodeJS
+  add_custom_command(
+    OUTPUT "atspi_nodejs_inspect_wrap.cxx"
+    COMMAND swig -c++ -javascript -node -o atspi_nodejs_inspect_wrap.cxx -I${CMAKE_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/atspi_inspect.i
+    VERBATIM
+  )
+
+  ## Generate NodeJS module
+  add_custom_command(
+    OUTPUT "build/Release/atspi_inspect.node"
+    DEPENDS atspi_nodejs_inspect_wrap.cxx
+    COMMAND ${NODE_GYP} configure build
+    VERBATIM
+  )
+endif (ATSPI_NODEJS_MODULE)

--- a/lib/atspi/binding.gyp.in
+++ b/lib/atspi/binding.gyp.in
@@ -1,0 +1,23 @@
+{
+  "targets": [
+    {
+      "target_name": "atspi_inspect",
+      "include_dirs": [
+        "${CMAKE_CURRENT_SOURCE_DIR}",
+        "${CMAKE_SOURCE_DIR}/include",
+      ],
+      "sources": [
+        "../../../lib/atspi/linux_utils.cc",
+        "../../../lib/atspi/atspi_node.cc",
+        "./atspi_nodejs_inspect_wrap.cxx",
+      ],
+      "cflags": [
+        "<!@(pkg-config \"atspi-2\" --cflags)",
+      ],
+      "ldflags": [
+        "<!@(pkg-config \"atspi-2\" --libs)",
+        "-lv8",
+      ],
+    }
+  ]
+}


### PR DESCRIPTION
It uses swig + node-gyp. Although swig alone can generate a shared object with the bindings for V8, node-gyp is needed to generate a working module ready to be require()'ed into NodeJS code.

The integration in cmake is a bit tricky, with node-gyp being a parallel build system to cmake. The result is a file
`atspi_inspect.node` in `${BUILD}/lib/atspi`, which can directly be used from Node as so:

```
const AX_atspi = require("<BUILD_DIR>/lib/atspi_inspect");

const root = AX_atspi.find_root_accessible_from_pid(<PID>);
if (root)
  console.log (root.accessible_get_name(), root.accessible_get_role_name());
```
    
Fixes #11