### PR TITLE
[ATSPI] Add API to support tree traversal

### DIFF
--- a/include/axaccess/atspi/atspi_node.h
+++ b/include/axaccess/atspi/atspi_node.h
@@ -1,9 +1,14 @@
 #ifndef LIB_ATSPI_ATSPI_NODE_H_
 #define LIB_ATSPI_ATSPI_NODE_H_
 
+#include <memory>
 #include <string>
+#include <vector>
 
 #include <atspi/atspi.h>
+
+class AtspiNode;
+typedef std::unique_ptr<AtspiNode> AtspiNodePtr;
 
 class AtspiNode {
   AtspiAccessible* accessible_;
@@ -14,6 +19,9 @@ class AtspiNode {
 
     std::string accessible_get_role_name();
     std::string accessible_get_name();
+    int32_t accessible_get_child_count();
+    AtspiNodePtr accessible_get_child_at_index(int32_t index);
+    std::vector<AtspiNodePtr> accessible_get_children();
 };
 
 #endif // LIB_ATSPI_ATSPI_NODE_H_

--- a/include/axaccess/atspi/linux_utils.h
+++ b/include/axaccess/atspi/linux_utils.h
@@ -6,8 +6,6 @@
 
 #include "atspi_node.h"
 
-using AtspiNodePtr = std::unique_ptr<AtspiNode>;
-
 AtspiNodePtr find_root_accessible_from_pid(const int pid);
 
 #endif // LIB_ATSPI_LINUX_UTILS_H_

--- a/lib/atspi/atspi_node.cc
+++ b/lib/atspi/atspi_node.cc
@@ -28,7 +28,53 @@ std::string AtspiNode::accessible_get_name() {
   char* name = atspi_accessible_get_name(accessible_, &error);
   if (error) {
     std::cerr << error->message;
+    g_error_free(error);
     return "";
   }
   return name;
+}
+
+int32_t AtspiNode::accessible_get_child_count() {
+  GError* error = nullptr;
+  gint count = atspi_accessible_get_child_count(accessible_, &error);
+  if (error) {
+    std::cerr << error->message;
+    g_error_free(error);
+    return -1;
+  }
+  return (int32_t) count;
+}
+
+AtspiNodePtr AtspiNode::accessible_get_child_at_index(int32_t index) {
+  GError* error = nullptr;
+  AtspiAccessible* child =
+    atspi_accessible_get_child_at_index(accessible_, index, &error);
+  if (error) {
+    std::cerr << error->message;
+    g_error_free(error);
+    return nullptr;
+  }
+  return std::make_unique<AtspiNode>(AtspiNode(child));
+}
+
+std::vector<AtspiNodePtr> AtspiNode::accessible_get_children() {
+  std::vector<AtspiNodePtr> result(0);
+
+  GError* error = nullptr;
+  gint child_count = atspi_accessible_get_child_count(accessible_, &error);
+  if (error) {
+    std::cerr << error->message;
+    g_error_free(error);
+    return result;
+  }
+
+  result.resize(child_count);
+
+  for (auto i = 0; i < child_count; i++) {
+    AtspiNodePtr child_node = accessible_get_child_at_index(i);
+    if (child_node)
+      result[i].swap(child_node);
+  }
+
+  return result;
 }

--- a/lib/atspi/dump_tree_atspi.cc
+++ b/lib/atspi/dump_tree_atspi.cc
@@ -9,6 +9,25 @@ void print_usage(std::string& program_name) {
     std::cout << "Usage: "<< program_name << " <pid>\n";
 }
 
+static void print_node(AtspiNodePtr& node, int level) {
+  for (auto i = 0; i < level; i++)
+    std::cout << "--";
+  std::cout << "> " << node->accessible_get_role_name();
+  std::string node_name = node->accessible_get_name();
+  if (!node_name.empty())
+    std::cout << " (" << node_name << ")";
+  std::cout << "\n";
+
+  int32_t child_count = node->accessible_get_child_count();
+  if (child_count < 0)
+    return;
+
+  for (auto i = 0; i < child_count; i++) {
+    auto child = node->accessible_get_child_at_index(i);
+    print_node(child, level + 1);
+  }
+}
+
 int main(int argc, char** argv) {
     std::string program_name(argv[0]);
 
@@ -27,8 +46,12 @@ int main(int argc, char** argv) {
     const int pid = std::stoi(pid_string);
     std::cout << "Got PID: " << pid << "\n";
     AtspiNodePtr root = find_root_accessible_from_pid(pid);
+    if (!root) {
+      std::cerr << "No accessible root found at pid " << pid << "\n";
+      return -1;
+    }
 
-    std::cout << "root accessible name: " << root->accessible_get_name() << "\n";
-    std::cout << "root accessible role: " << root->accessible_get_role_name() << "\n";
+    print_node(root, 0);
+
     return 0;
 }


### PR DESCRIPTION
This series add various methods to `AtspiNode` to support tree traversal. The new methods are:

- accessible_get_child_count()
- accessible_get_child_at_index()
- accessible_get_children()

The names are self-explanatory.  The first two map directly to the counter-parts in AT-SPI C library, while the third is a
convenient one added to support getting all children of a node at once.

The `dump_tree_atspi` program is updated to actually dump the accessible tree, using the newly added API.

The bonus commit in the series add a destructor to `AtspiNode` that calls `g_object_unref()` to release the wrapped  `AtspiAccessible` object, otherwise we get a mem leak.

There were also a couple of calls to `g_error_free()` missing.

Fixes #20