### PR TITLE
Fix linking errors for linux

### DIFF
--- a/lib/atspi/CMakeLists.txt
+++ b/lib/atspi/CMakeLists.txt
@@ -12,6 +12,8 @@ add_library(
   linux_utils.cc
   axa_context_impl.cc
   axa_node_impl.cc
+  ../node.cc
+  ../context.cc
 )
 
 # CMake module that can find system c++ librarys


### PR DESCRIPTION
Hi @elima -- I also get another error when I build locally on linux, separately form the header `#include "axa_exports.h"`.

Its the following:
```
[ 58%] Linking CXX executable dump_tree_atspi
/usr/bin/ld: libatspi_inspect.so: undefined reference to `axa::Node::Create(std::unique_ptr<axa::NodeImpl, std::default_delete<axa::NodeImpl> >)'
collect2: error: ld returned 1 exit status
make[2]: *** [lib/atspi/CMakeFiles/dump_tree_atspi.dir/build.make:98: lib/atspi/dump_tree_atspi] Error 1
make[1]: *** [CMakeFiles/Makefile2:221: lib/atspi/CMakeFiles/dump_tree_atspi.dir/all] Error 2
make: *** [Makefile:91: all] Error 2

```

And it's fixed by this change. But are you not getting this error?