### PR TITLE
Move public headers to build dir to mix with generated files

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(
 target_include_directories(
   dump_tree
   PUBLIC
-    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_BINARY_DIR}/include
 )
 
 target_link_libraries(

--- a/include/axaccess/context.h
+++ b/include/axaccess/context.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <memory>
-#include "axa_export.h"
+#include "axaccess/export.h"
 
 #include "./node.h"
 

--- a/include/axaccess/ia2/ia2_node.h
+++ b/include/axaccess/ia2/ia2_node.h
@@ -4,7 +4,7 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include "axa_export.h"
+#include "axaccess/export.h"
 
 class IA2Node;
 typedef std::unique_ptr<IA2Node> IA2NodePtr;

--- a/include/axaccess/ia2/win_utils.h
+++ b/include/axaccess/ia2/win_utils.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 #include <string>
-#include "axa_export.h"
+#include "axaccess/export.h"
 
 #include "ia2_node.h"
 

--- a/include/axaccess/node.h
+++ b/include/axaccess/node.h
@@ -2,7 +2,7 @@
 
 #include <memory>
 #include <string>
-#include "axa_export.h"
+#include "axaccess/export.h"
 
 namespace axa {
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,7 +1,20 @@
+# Public headers
+
+add_custom_target(
+  pub_headers
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
+  VERBATIM
+)
+
 # Main library (libaxaccess.so)
 add_library(
   axaccess
   SHARED
+)
+
+add_dependencies(
+  axaccess
+  pub_headers
 )
 
 set(
@@ -16,7 +29,7 @@ include(GenerateExportHeader)
 generate_export_header(
   axaccess
   BASE_NAME axa
-  EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/exports/axa_export.h
+  EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/axaccess/export.h
 )
 target_compile_definitions(
   axaccess
@@ -76,6 +89,5 @@ target_sources(
 target_include_directories(
   axaccess
   PUBLIC
-    ${PROJECT_SOURCE_DIR}/include
-    ${PROJECT_BINARY_DIR}/exports  # axa_export.h
+    ${PROJECT_BINARY_DIR}/include
 )

--- a/lib/atspi/CMakeLists.txt
+++ b/lib/atspi/CMakeLists.txt
@@ -33,7 +33,7 @@ target_include_directories(
   atspi_inspect
 
   PUBLIC
-    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_BINARY_DIR}/include
     ${ATSPI2_INCLUDE_DIRS}
 )
 

--- a/lib/atspi/binding.gyp.in
+++ b/lib/atspi/binding.gyp.in
@@ -4,7 +4,7 @@
       "target_name": "atspi_inspect",
       "include_dirs": [
         "${CMAKE_CURRENT_SOURCE_DIR}",
-        "${CMAKE_SOURCE_DIR}/include",
+        "${CMAKE_BINARY_DIR}/include",
       ],
       "sources": [
         "../../../lib/atspi/linux_utils.cc",

--- a/lib/ia2/CMakeLists.txt
+++ b/lib/ia2/CMakeLists.txt
@@ -12,8 +12,7 @@ target_include_directories(
   ia2_inspect
 
   PUBLIC
-    ${PROJECT_SOURCE_DIR}/include
-    ${PROJECT_BINARY_DIR}/exports  # axa_import.h
+    ${PROJECT_BINARY_DIR}/include
 )
 
 target_compile_definitions(


### PR DESCRIPTION
Move public headers to build dir to mix with generated files.
    
This adds a custom target that will copy headers from source dir's `include/` to build dir's `include`. Then the     generated `export.h` file will be placed there.
    
The purpose is to keep public headers self-contained, so that they don't reference any file in the build dir.
    
The install target will then just copy ${BUILD_DIR}/include to whatever $PREFIX.
    
* Use cross platform cmake copy command.