### PR TITLE
Add github workflow that builds the NodeJS module on Linux (atspi_inspect.node)

### DIFF
--- a/.github/workflows/build_nodejs_module.yml
+++ b/.github/workflows/build_nodejs_module.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build_nodejs_module:
+    name: Build NodeJS module on Linux (Ubuntu)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install System dependencies
+        run: sudo apt install -y libatspi2.0-dev libnode-dev
+      - name: Install node-gyp
+        run: sudo npm install -g node-gyp
+      - name: Install SWIG 4.1.0
+        run: |
+          wget "https://github.com/swig/swig/archive/refs/tags/v4.1.0.tar.gz"
+          tar -axf v4.1.0.tar.gz
+          cd swig-4.1.0
+          ./autogen.sh
+          ./configure
+          make -j
+          sudo make install
+      - uses: actions/checkout@v3
+      - name: Configure Project
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DAXA_NODEJS_MODULE=ON
+      - name: Build project
+        run: |
+          cd build
+          make -j


### PR DESCRIPTION
fixes #67

@elima is taking over this :) My original goal for this PR:
1. Install dependencies
2. Build the dump_tree_atspi
4. Run an application we can get accessibility information for
5. Get the PID
6. Run dump_tree_atspi <pid>

Questions and related work:
- [ ] should we use some kind of c++ dependency management system for c++? Like one of these? https://github.com/Igalia/AXAccess/issues/4
- [ ] we should have some test for the nodejs bindings as well