### PR TITLE
Add pre-commit config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: Chromium

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+-  repo: https://github.com/pre-commit/mirrors-clang-format
+   rev: v17.0.6
+   hooks:
+   -    id: clang-format
+        types_or: [c++, javascript, objective-c]
+        args: ["-style=file"]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ For NodeJS module (optional):
 
 These bindings dependencies are on my default. See *Feature Flags* section below for how to disable them.
 
+For `pre-commit`:
+* `pip install pre-commit`
+* `pip install clang-format`
+* `pre-commit install`
+
+
 #### Build steps
 ```
 % mkdir build
@@ -79,6 +85,11 @@ For the nodeJS bindings, you will need to download and build node-gyp app and pu
 ```
 npm install -g node-gyp
 ```
+
+For `pre-commit`:
+* `pip install pre-commit`
+* `pip install clang-format`
+* `pre-commit install`
 
 #### Build steps
 


### PR DESCRIPTION
This adds configuration for [pre-commit](https://pre-commit.com/) and [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html), and instructions for how to set up pre-commit locally.

Once you set up pre-commit locally, each time you commit, pre-commit will run ClangFormat, trim trailing whitespace and ensure each text file ends with a newline. If these steps cause any changes to your code, it will halt the commit so that you can check the changes.