### PR TITLE
[ATSPI] Make `atspi_inspect` target depend on `pub_headers`

### DIFF
--- a/lib/atspi/CMakeLists.txt
+++ b/lib/atspi/CMakeLists.txt
@@ -28,6 +28,11 @@ pkg_check_modules(
   # Module name
   "atspi-2")
 
+add_dependencies(
+  atspi_inspect
+  pub_headers
+)
+
 # With this, we can #include "atspi/atspi.h"
 target_include_directories(
   atspi_inspect


### PR DESCRIPTION
This is to make sure that public headers are copied to `build/include` before `atspi_inspect` library is built, fixing a potential issue where atspi_inspect target fails because it can't find the headers.