### PR TITLE
Update README.md to add extra steps needed for building on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@
 
 #### Dependencies
 
+On Debian-like systems:
+
 `sudo apt install cmake libatspi2.0-dev`
 
 For Python3 bindings (optional):
 * `sudo apt install swig python3-dev`
 
 For NodeJS module (optional):
-* `sudo apt install swig node-gyp`
+* `sudo apt install swig libnode-dev node-gyp`
 
 These bindings dependencies are on my default. See *Feature Flags* section below for how to disable them.
 
@@ -19,6 +21,12 @@ For `pre-commit`:
 * `pip install clang-format`
 * `pre-commit install`
 
+There is a known issue linking the NodeJS module with the Debian default linker. So using the gold linker
+is recommended:
+
+```
+$ sudo ln -sf /usr/bin/ld.gold /usr/bin/ld
+```
 
 #### Build steps
 ```


### PR DESCRIPTION
Namely, add `libnode-dev` to NodeJS module dependencies section, which will pull v8 development files.

Also, added section recommending to use the gold linker, instead of Debian's default.