### PR TITLE
Find any application, not just Chrome, on Windows (#115)

### DIFF
--- a/examples/ia2/dump_tree_ia2.cc
+++ b/examples/ia2/dump_tree_ia2.cc
@@ -1,12 +1,22 @@
 #include <iostream>
+#include <map>
 #include <ostream>
 #include <regex>
 #include <string>
 
 #include "include/axaccess/ia2/ia2_node.h"
 
-void print_usage(std::string& program_name) {
-  std::cout << "Usage: " << program_name << " <pid>\n";
+void print_usage(std::string& program_path) {
+  std::string program_name = program_path;
+  size_t pos = program_name.find_last_of("\\");
+  if (pos != std::string::npos) {
+    program_name = program_name.substr(pos + 1);
+  }
+
+  std::cout << "Usage:\n";
+  std::cout << "  " << program_name << " --name=NAME\n";
+  std::cout << "  " << program_name << " --pid=PID\n";
+  std::cout << "  " << program_name << " --name=NAME --pid=PID\n";
 }
 
 static void print_node(IA2NodePtr& node, int level) {
@@ -36,17 +46,47 @@ static void print_node(IA2NodePtr& node, int level) {
   }
 }
 
-int main(int argc, char** argv) {
-  std::string program_name(argv[0]);
-
-  if (argc != 2) {
-    print_usage(program_name);
-    return 1;
+std::map<std::string, std::string> parse_arguments(int argc, char** argv) {
+  std::map<std::string, std::string> argument_map;
+  for (int i = 1; i < argc; ++i) {
+    std::string arg(argv[i]);
+    size_t pos = arg.find('=');
+    if (pos != std::string::npos) {
+      // Argument format is --key=value
+      std::string key = arg.substr(0, pos);
+      std::string value = arg.substr(pos + 1);
+      argument_map[key] = value;
+    } else {
+      // Argument format is --key value, assuming there is a value.
+      std::string key = arg;
+      if (i + 1 < argc) {
+        argument_map[key] = argv[++i];
+      }
+    }
   }
 
-  std::string pid_string(argv[1]);
-  std::regex number_regex("\\d+");
-  if (!std::regex_match(pid_string, number_regex)) {
+  return argument_map;
+}
+
+int main(int argc, char** argv) {
+  std::string program_name(argv[0]);
+  auto args = parse_arguments(argc, argv);
+
+  std::string name;
+  if (args.find("--name") != args.end()) {
+    name = args["--name"];
+  }
+
+  int pid = 0;
+  if (args.find("--pid") != args.end()) {
+    std::string pid_string = args["--pid"];
+    std::regex number_regex("\\d+");
+    if (std::regex_match(pid_string, number_regex)) {
+      pid = std::stoi(pid_string);
+    }
+  }
+
+  if (name.empty() && !pid) {
     print_usage(program_name);
     return 1;
   }
@@ -54,11 +94,16 @@ int main(int argc, char** argv) {
   // TODO: experiment with where to put coinitialize and couninitialize. #93
   CoInitialize(nullptr);
 
-  const int pid = std::stoi(pid_string);
-  std::cout << "Got PID: " << pid << "\n";
-  IA2NodePtr root = IA2Node::CreateForPID(pid);
+  IA2NodePtr root = IA2Node::CreateRootForName(name, pid);
   if (!root) {
-    std::cerr << "No accessible root found at pid " << pid << "\n";
+    std::cerr << "ERROR: Could not find match for";
+    if (!name.empty()) {
+      std::cerr << " name: '" << name << "'";
+    }
+    if (pid) {
+      std::cerr << " PID: " << pid;
+    }
+    std::cerr << std::endl;
     return -1;
   }
 

--- a/include/axaccess/ia2/ia2_node.h
+++ b/include/axaccess/ia2/ia2_node.h
@@ -23,7 +23,10 @@ class AXA_EXPORT IA2Node {
   };
   ~IA2Node(){};
 
-  static IA2NodePtr CreateForPID(const int pid);
+  static IA2NodePtr CreateRootForName(const std::string& name,
+                                      const int pid = 0);
+  static IA2NodePtr CreateRootForPID(const int pid);
+
   // testing
   static void DumpRoleTree(const int pid);
 

--- a/include/axaccess/ia2/win_utils.h
+++ b/include/axaccess/ia2/win_utils.h
@@ -11,7 +11,8 @@
 
 namespace win_utils {
 
-AXA_EXPORT Microsoft::WRL::ComPtr<IAccessible> GetAccessibleFromProcessID(
+AXA_EXPORT Microsoft::WRL::ComPtr<IAccessible> GetAccessibleRoot(
+    const std::string& name,
     DWORD dwProcessID);
 
 AXA_EXPORT std::string nameFromHwnd(HWND hwnd);

--- a/lib/ia2/ia2_node.cc
+++ b/lib/ia2/ia2_node.cc
@@ -264,8 +264,18 @@ std::string IA2RoleToString(LONG role) {
 }
 }  // Namespace
 
-IA2NodePtr IA2Node::CreateForPID(const int pid) {
-  Microsoft::WRL::ComPtr<IAccessible> root = GetAccessibleFromProcessID(pid);
+IA2NodePtr IA2Node::CreateRootForName(const std::string& app_name,
+                                      const int pid) {
+  Microsoft::WRL::ComPtr<IAccessible> root = GetAccessibleRoot(app_name, pid);
+  if (!root) {
+    return nullptr;
+  }
+
+  return std::make_unique<IA2Node>(IA2Node(root));
+}
+
+IA2NodePtr IA2Node::CreateRootForPID(const int pid) {
+  Microsoft::WRL::ComPtr<IAccessible> root = GetAccessibleRoot("", pid);
   if (!root) {
     return nullptr;
   }

--- a/lib/ia2/win_utils.cc
+++ b/lib/ia2/win_utils.cc
@@ -1,7 +1,10 @@
 #include "axaccess/ia2/win_utils.h"
 
 #include <stdlib.h>
+#include <algorithm>
+#include <cctype>
 #include <iostream>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -12,6 +15,12 @@
 #include "third_party/ia2/include/ia2/ia2_api_all.h"
 
 namespace win_utils {
+
+struct WindowSearchCriteria {
+  std::optional<std::string> name;
+  std::optional<DWORD> pid;
+  HWND match = nullptr;
+};
 
 std::string nameFromHwnd(HWND hwnd) {
   int length = ::GetWindowTextLength(hwnd);
@@ -25,34 +34,60 @@ std::string nameFromHwnd(HWND hwnd) {
   return title;
 }
 
-// TODO: This is not the right API -- probably we should copy chrome code
-// and find a hwnd by titla alone. Right now this only returns a Google Chrome
-// HWND. But if I don't include PID, then I get other processess with google
-// chrome in name
-Microsoft::WRL::ComPtr<IAccessible> GetAccessibleFromProcessID(
-    DWORD dwProcessID) {
-  Microsoft::WRL::ComPtr<IAccessible> root;
-  HWND hwnd = nullptr;
-  do {
-    hwnd = FindWindowEx(nullptr, hwnd, nullptr, nullptr);
+std::string lower(const std::string& str) {
+  std::string result = str;
+  std::transform(result.begin(), result.end(), result.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return result;
+}
 
-    DWORD checkProcessID = 0;
-    GetWindowThreadProcessId(hwnd, &checkProcessID);
-    if (checkProcessID == dwProcessID) {
-      std::string title = nameFromHwnd(hwnd);
-      if (title.find("Google Chrome") != std::string::npos) {
-        break;
-      }
+BOOL CALLBACK FindWindow(HWND hwnd, LPARAM lparam) {
+  WindowSearchCriteria* criteria =
+      reinterpret_cast<WindowSearchCriteria*>(lparam);
+
+  bool has_name = criteria->name.has_value() && !criteria->name.value().empty();
+  bool has_pid = criteria->pid.has_value() && criteria->pid.value();
+  if (!has_name && !has_pid) {
+    std::cerr << "ERROR: FindWindow requires a name and/or PID" << std::endl;
+    return FALSE;
+  }
+
+  DWORD window_pid;
+  GetWindowThreadProcessId(hwnd, &window_pid);
+  if (has_pid && window_pid != criteria->pid.value()) {
+    return TRUE;
+  }
+
+  std::string title = lower(nameFromHwnd(hwnd));
+  if (has_name) {
+    std::string name = lower(criteria->name.value());
+    if (title.find(name) == std::string::npos) {
+      return TRUE;
     }
-  } while (hwnd != nullptr);
+  }
 
-  if (hwnd == nullptr) {
-    std::cout << "Could not find hwnd\n";
+  std::cout << "Window found: " << nameFromHwnd(hwnd);
+  if (has_pid) {
+    std::cout << " - PID: " << criteria->pid.value();
+  }
+  std::cout << std::endl;
+  criteria->match = hwnd;
+  return FALSE;
+}
+
+Microsoft::WRL::ComPtr<IAccessible> GetAccessibleRoot(const std::string& name,
+                                                      DWORD dwProcessID) {
+  Microsoft::WRL::ComPtr<IAccessible> root;
+  WindowSearchCriteria criteria;
+  criteria.name = name;
+  criteria.pid = dwProcessID;
+  EnumWindows(FindWindow, reinterpret_cast<LPARAM>(&criteria));
+  if (criteria.match == nullptr) {
     return root;
   }
   // TODO: Consider using OBJID_CLIENT, but I think we want OBJID_WINDOW
-  HRESULT hr =
-      ::AccessibleObjectFromWindow(hwnd, OBJID_WINDOW, IID_PPV_ARGS(&root));
+  HRESULT hr = ::AccessibleObjectFromWindow(criteria.match, OBJID_WINDOW,
+                                            IID_PPV_ARGS(&root));
   if (FAILED(hr)) {
     std::cout << "Could not get accessible\n";
   }


### PR DESCRIPTION
* Make `name` a required command-line argument.
* Make `pid` an optional command-line argument.
* Replace GetAccessibleFromProcessID with GetAccessibleRoot which performs a case-insensitive substring search to locate a window whose title contains the provided name. If a pid has been provided, and is non-zero, the pid must also match.
* Rename CreateRoot to CreateRootForName
* Add CreateRootForPID, which has the same functionality as CreateForPID
* Make the name optional in WindowSearchCriteria
* Rename FindWindowWithName to FindWindow
* Update print_usage to reflect the new options
* Clean up the stdout and stderr text