### PR TITLE
[ATSPI] Fix symbol not found error in python bindings

### DIFF
--- a/lib/atspi/CMakeLists.txt
+++ b/lib/atspi/CMakeLists.txt
@@ -10,9 +10,16 @@ add_library(
   # Sources
   atspi_node.cc
   linux_utils.cc
-  axa_context_impl.cc
-  axa_node_impl.cc
 )
+
+if (AXA_LIBAXACCESS)
+  target_sources(
+    atspi_inspect
+    PRIVATE
+    axa_context_impl.cc
+    axa_node_impl.cc
+  )
+endif (AXA_LIBAXACCESS)
 
 # CMake module that can find system c++ librarys
 find_package(


### PR DESCRIPTION
We should not build the cross-platform API wrappers as part atspi_inspect library when libaxaccess is not going to be built and linked to it.