### PR TITLE
Mac library CMAKE clean up tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ As well as a python module:
 ```
 % cd build/lib/mac/
 % python3
->>> import mac_inspect
->>> app = mac_inspect.AXAPINode.CreateForPID(12345)
+>>> import axapi_inspect
+>>> app = axapi_inspect.AXAPINode.CreateForPID(12345)
 >>> attribute_names = app.CopyAttributeNames()
 >>> role = app.CopyStringAttributeValue('AXRole')
 >>> title = app.CopyStringAttributeValue('AXTitle')

--- a/examples/atspi/CMakeLists.txt
+++ b/examples/atspi/CMakeLists.txt
@@ -15,7 +15,7 @@ if (AXA_NODEJS_MODULE)
     ALL
     DEPENDS
       atspi_inspect
-      atspi_inspect_module
+      atspi_inspect_nodejs_module
     COMMAND
       ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/dump_tree_atspi.js ${CMAKE_CURRENT_BINARY_DIR}/
   )

--- a/examples/mac/CMakeLists.txt
+++ b/examples/mac/CMakeLists.txt
@@ -13,5 +13,5 @@ target_link_libraries(
   dump_tree_mac
 
   # Items to link into the target
-  PRIVATE mac_inspect
+  PRIVATE axapi_inspect
 )

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -60,7 +60,7 @@ if (AXA_LIBAXACCESS)
     target_link_libraries(
       axaccess
       PRIVATE
-        mac_inspect
+        axapi_inspect
     )
   endif (APPLE)
 endif (AXA_LIBAXACCESS)

--- a/lib/atspi/CMakeLists.txt
+++ b/lib/atspi/CMakeLists.txt
@@ -128,14 +128,14 @@ if (AXA_NODEJS_MODULE)
   )
 
   add_custom_target(
-    atspi_inspect_module ALL
+    atspi_inspect_nodejs_module ALL
     DEPENDS
       atspi_inspect
       atspi_inspect.node
   )
 
   set_property(
-    TARGET atspi_inspect_module
+    TARGET atspi_inspect_nodejs_module
     APPEND
     PROPERTY ADDITIONAL_CLEAN_FILES
       binding.gyp

--- a/lib/mac/CMakeLists.txt
+++ b/lib/mac/CMakeLists.txt
@@ -4,13 +4,20 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET 13.0)
 
 add_library(
   # Name
-  mac_inspect
+  axapi_inspect
 
   # Sources
   axapi_node.mm
-  axapi_node_impl.cc
-  axapi_context_impl.cc
 )
+
+if (AXA_LIBAXACCESS)
+  target_sources(
+    axapi_inspect
+    PRIVATE
+    axa_context_impl.cc
+    axa_node_impl.cc
+  )
+endif (AXA_LIBAXACCESS)
 
 find_library(APPLICATION_SERVICES_FRAMEWORK ApplicationServices)
 cmake_print_variables(APPLICATION_SERVICES_FRAMEWORK)
@@ -18,7 +25,7 @@ find_library(FOUNDATION_FRAMEWORK Foundation)
 cmake_print_variables(FOUNDATION_FRAMEWORK)
 
 target_include_directories(
-  mac_inspect
+  axapi_inspect
 
   PUBLIC
     ${PROJECT_BINARY_DIR}/include
@@ -26,7 +33,7 @@ target_include_directories(
 )
 
 target_link_libraries(
-  mac_inspect
+  axapi_inspect
 
   PRIVATE
     ${APPLICATION_SERVICES_FRAMEWORK}
@@ -41,7 +48,7 @@ if (AXA_PYTHON_MODULE OR AXA_NODEJS_MODULE)
   include(UseSWIG)
 endif()
 
-# SWIG Instructions to build a python module called "mac_inspect"
+# SWIG Instructions to build a python module called "axapi_inspect"
 
 if (AXA_PYTHON_MODULE)
   find_package(Python3 COMPONENTS Interpreter Development)
@@ -49,18 +56,19 @@ if (AXA_PYTHON_MODULE)
   include_directories(${CMAKE_CURRENT_SOURCE_DIR})
   include_directories(${Python3_INCLUDE_DIRS})
 
-  set_property(SOURCE mac_inspect.i PROPERTY CPLUSPLUS ON)
+  set_property(SOURCE axapi_inspect.i PROPERTY CPLUSPLUS ON)
 
+  # TODO: how to se the name of this library????
   swig_add_library(
     # The name of the c++ library used by python module
-    mac_python_inspect
+    axapi_python_inspect
     TYPE SHARED
     LANGUAGE python
-    SOURCES mac_inspect.i
+    SOURCES axapi_inspect.i
   )
 
   set_target_properties(
-    mac_python_inspect
+    axapi_python_inspect
 
     PROPERTIES
     SUFFIX .so
@@ -68,15 +76,15 @@ if (AXA_PYTHON_MODULE)
 
   target_link_libraries(
     # Target to link
-    mac_python_inspect
+    axapi_python_inspect
 
     # Items to link into the target
-    mac_inspect
+    axapi_inspect
     ${Python3_LIBRARIES}
   )
 
   set_property(
-    TARGET mac_python_inspect
+    TARGET axapi_python_inspect
     PROPERTY
       SWIG_USE_TARGET_INCLUDE_DIRECTORIES TRUE
   )
@@ -90,21 +98,6 @@ if (AXA_NODEJS_MODULE)
     REQUIRED
   )
 
-  # Final cmake target and proper destination for the NodeJS module
-  add_custom_target(
-    axapi_inspect.node ALL
-    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/build/Release/axapi_inspect.node"
-    COMMAND cp "./build/Release/axapi_inspect.node" .
-  )
-
-  set_property(
-    TARGET axapi_inspect.node
-    APPEND
-    PROPERTY ADDITIONAL_CLEAN_FILES
-      ${CMAKE_CURRENT_BINARY_DIR}/build
-      axapi_inspect.node
-  )
-
   # Generate `binding.gyp` file for node-gyp
   configure_file(
     binding.gyp.in binding.gyp
@@ -112,16 +105,43 @@ if (AXA_NODEJS_MODULE)
 
   # Generate C++ wrapper for NodeJS
   add_custom_command(
-    OUTPUT "axapi_nodejs_inspect_wrap.cxx"
-    COMMAND swig -c++ -javascript -node -o axapi_nodejs_inspect_wrap.cxx -I${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/mac_inspect.i
+    OUTPUT axapi_nodejs_inspect_wrap.cxx
+    DEPENDS
+      "${CMAKE_CURRENT_SOURCE_DIR}/axapi_inspect.i"
+    COMMAND
+      swig -c++ -javascript -node -o axapi_nodejs_inspect_wrap.cxx -I${CMAKE_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/axapi_inspect.i"
     VERBATIM
   )
 
   # Generate NodeJS module
   add_custom_command(
-    OUTPUT "build/Release/axapi_inspect.node"
-    DEPENDS axapi_nodejs_inspect_wrap.cxx
-    COMMAND ${NODE_GYP} configure build
+    OUTPUT axapi_inspect.node
+    DEPENDS
+      libaxapi_inspect.a
+      binding.gyp
+      axapi_nodejs_inspect_wrap.cxx
+    COMMAND
+      ${NODE_GYP} configure build
+      COMMAND cp "./build/Release/axapi_inspect.node" .
     VERBATIM
   )
+
+  # Final cmake target and proper destination for the NodeJS module
+  add_custom_target(
+    axapi_inspect_node_module ALL
+    DEPENDS
+      axapi_inspect
+      axapi_inspect.node
+  )
+
+  set_property(
+    TARGET axapi_inspect_node_module
+
+    APPEND
+    PROPERTY ADDITIONAL_CLEAN_FILES
+      binding.gyp
+      ${CMAKE_CURRENT_BINARY_DIR}/build
+      axapi_inspect.node
+  )
+
 endif (AXA_NODEJS_MODULE)

--- a/lib/mac/axapi_inspect.i
+++ b/lib/mac/axapi_inspect.i
@@ -1,4 +1,4 @@
-%module mac_inspect
+%module axapi_inspect
 
 %{
 #include <include/axaccess/mac/axapi_node.h>


### PR DESCRIPTION
* Change all targets to be called "axapi_inspect" instead of "mac_inspect" for internal consistency (and matching other APIs)
* Rebuild nodejs module when c++ files change (same as #130)
* Don't include cross platform library files when not building (same as #124)