### PR TITLE
[ATSPI] Load node module locally in `dump_tree_atspi.js`

### DIFF
--- a/examples/atspi/CMakeLists.txt
+++ b/examples/atspi/CMakeLists.txt
@@ -35,5 +35,8 @@ if (AXA_NODEJS_MODULE)
       atspi_inspect_module
     COMMAND
       ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/dump_tree_atspi.js ${CMAKE_CURRENT_BINARY_DIR}/
+    COMMAND
+      ${CMAKE_COMMAND} -E create_symlink ${CMAKE_BINARY_DIR}/lib/atspi/atspi_inspect.node ${CMAKE_CURRENT_BINARY_DIR}/atspi_inspect.node
+    VERBATIM
   )
 endif (AXA_NODEJS_MODULE)

--- a/examples/atspi/dump_tree_atspi.js
+++ b/examples/atspi/dump_tree_atspi.js
@@ -14,7 +14,7 @@ if (!pid || typeof (pid) != 'number') {
   process.exit();
 }
 
-const atspi = require('../../lib/atspi/atspi_inspect');
+const atspi = require('./atspi_inspect');
 
 const root = atspi.find_root_accessible_from_pid(pid);
 if (root.is_null()) {


### PR DESCRIPTION
Currently, we are loading `atspi_inspect.node` from its target location under `<BUILD>/lib/atspi`. Following what we did for Python, this patch loads the module from the same directory as the example itself (`<BUILD>/examples/atspi`), creating a local symlink of the module.

What this change does in practice is to centralize the knowledge of the build tree structure in CMake files, rather than having the logic spread between cmake files and code in the examples; with the hope of making it more maintainable.