### PR TITLE
[ATSPI] Fix double-free error in AtspiNode::GetRelations()

### DIFF
--- a/lib/atspi/atspi_node.cc
+++ b/lib/atspi/atspi_node.cc
@@ -253,7 +253,6 @@ std::vector<std::string> AtspiNode::getRelations() const {
     AtspiRelation* relation = g_array_index(relation_array, AtspiRelation*, i);
     AtspiRelationType relation_type =
         atspi_relation_get_relation_type(relation);
-    g_free(relation);
     relations.push_back(RelationTypeToString(relation_type));
   }
   g_array_free(relation_array, TRUE);


### PR DESCRIPTION
The returned AtspiRelation objects are not owned by the caller, and g_array_free() call at the end of the loop already frees the array memory needed to store the list (see the 2nd argument, `free_segment` which is passed TRUE).

This is an overlook from #145.