### PR TITLE
Move cmake_minimum_required to first line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(AXAccess)
 cmake_minimum_required(VERSION 3.25)
+project(AXAccess)
 
 # Enable cmake_print_variables() and cmake_print_properties() for debugging
 include(CMakePrintHelpers)


### PR DESCRIPTION
We get a warning because this is not the first line.