### PR TITLE
Put all of the linux code in acacia namespace

### DIFF
--- a/examples/atspi/dump_tree_atspi.cc
+++ b/examples/atspi/dump_tree_atspi.cc
@@ -8,6 +8,8 @@
 
 #include "lib/utils.h"
 
+using acacia::AtspiNode;
+
 static void PrintUsage(std::string& program_path) {
   std::string program_name = program_path;
   size_t pos = program_name.find_last_of("/");
@@ -71,40 +73,40 @@ static void PrintNode(AtspiNode node, int level) {
 
   // We don't check if this is null because pretty much everything implements
   // it.
-  AtspiComponentInterface component = node.queryComponent();
+  acacia::AtspiComponentInterface component = node.queryComponent();
   std::cout << indent << "* Component: " << component.toString() << "\n";
 
-  AtspiActionInterface action = node.queryAction();
+  acacia::AtspiActionInterface action = node.queryAction();
   if (!action.isNull()) {
     std::cout << indent << "* Action: " << action.toString() << "\n";
   }
 
-  AtspiDocumentInterface document = node.queryDocument();
+  acacia::AtspiDocumentInterface document = node.queryDocument();
   if (!document.isNull()) {
     std::cout << indent << "* Document: " << document.toString() << "\n";
   }
 
-  AtspiHyperlinkInterface hyperlink = node.queryHyperlink();
+  acacia::AtspiHyperlinkInterface hyperlink = node.queryHyperlink();
   if (!hyperlink.isNull()) {
     std::cout << indent << "* Hyperlink: " << hyperlink.toString() << "\n";
   }
 
-  AtspiTableInterface table = node.queryTable();
+  acacia::AtspiTableInterface table = node.queryTable();
   if (!table.isNull()) {
     std::cout << indent << "* Table: " << table.toString() << "\n";
   }
 
-  AtspiTableCellInterface table_cell = node.queryTableCell();
+  acacia::AtspiTableCellInterface table_cell = node.queryTableCell();
   if (!table_cell.isNull()) {
     std::cout << indent << "* Table Cell: " << table_cell.toString() << "\n";
   }
 
-  AtspiTextInterface text = node.queryText();
+  acacia::AtspiTextInterface text = node.queryText();
   if (!text.isNull()) {
     std::cout << indent << "* Text: " << text.toString() << "\n";
   }
 
-  AtspiValueInterface value = node.queryValue();
+  acacia::AtspiValueInterface value = node.queryValue();
   if (!value.isNull()) {
     std::cout << indent << "* Value: " << value.toString() << "\n";
   }
@@ -141,9 +143,9 @@ int main(int argc, char** argv) {
 
   AtspiNode root;
   if (!name.empty()) {
-    root = findRootAtspiNodeForName(name, pid);
+    root = acacia::findRootAtspiNodeForName(name, pid);
   } else {
-    root = findRootAtspiNodeForPID(pid);
+    root = acacia::findRootAtspiNodeForPID(pid);
   }
 
   if (root.isNull()) {

--- a/include/acacia/atspi/atspi_action_interface.h
+++ b/include/acacia/atspi/atspi_action_interface.h
@@ -5,6 +5,8 @@
 
 #include <atspi/atspi.h>
 
+namespace acacia {
+
 /**
  * This object wraps an
  * [AtspiAction](https://docs.gtk.org/atspi2/iface.Action.html) pointer. It can
@@ -60,5 +62,7 @@ class AtspiActionInterface {
    */
   std::string getDescription(int index) const;
 };
+
+}  // namespace acacia
 
 #endif  // LIB_ATSPI_ATSPI_ACTION_H_

--- a/include/acacia/atspi/atspi_component_interface.h
+++ b/include/acacia/atspi/atspi_component_interface.h
@@ -5,6 +5,8 @@
 
 #include <atspi/atspi.h>
 
+namespace acacia {
+
 /**
  * This object wraps an
  * [AtspiComponent](https://docs.gtk.org/atspi2/iface.Component.html) pointer.
@@ -53,5 +55,7 @@ class AtspiComponentInterface {
    */
   std::pair<int, int> getSize() const;
 };
+
+}  // namespace acacia
 
 #endif  // LIB_ATSPI_ATSPI_COMPONENT_H_

--- a/include/acacia/atspi/atspi_document_interface.h
+++ b/include/acacia/atspi/atspi_document_interface.h
@@ -6,6 +6,8 @@
 
 #include <atspi/atspi.h>
 
+namespace acacia {
+
 /**
  * This object wraps an
  * [AtspiDocument](https://docs.gtk.org/atspi2/iface.Document.html) pointer. It
@@ -54,5 +56,7 @@ class AtspiDocumentInterface {
    */
   std::vector<std::string> getDocumentAttributes() const;
 };
+
+}  // namespace acacia
 
 #endif  // LIB_ATSPI_ATSPI_DOCUMENT_H_

--- a/include/acacia/atspi/atspi_hyperlink_interface.h
+++ b/include/acacia/atspi/atspi_hyperlink_interface.h
@@ -6,6 +6,8 @@
 
 #include <atspi/atspi.h>
 
+namespace acacia {
+
 /**
  * This object wraps an
  * [AtspiHyperlink](https://docs.gtk.org/atspi2/iface.Hyperlink.html) pointer.
@@ -72,5 +74,7 @@ class AtspiHyperlinkInterface {
   // TODO: Find a way to use a raw pointer by modifying something in SWIG.
   std::unique_ptr<AtspiHyperlink, void (*)(AtspiHyperlink*)> interface_;
 };
+
+}  // namespace acacia
 
 #endif  // LIB_ATSPI_ATSPI_HYPERLINK_H_

--- a/include/acacia/atspi/atspi_node.h
+++ b/include/acacia/atspi/atspi_node.h
@@ -15,6 +15,8 @@
 #include "acacia/atspi/atspi_text_interface.h"
 #include "acacia/atspi/atspi_value_interface.h"
 
+namespace acacia {
+
 /**
  * Represents a node in the AT-SPI accessibility tree. This object wraps an
  * [AtspiAccessible](https://docs.gtk.org/atspi2/class.Accessible.html) pointer.
@@ -209,5 +211,7 @@ class AtspiNode {
    */
   AtspiValueInterface queryValue() const;
 };
+
+}  // namespace acacia
 
 #endif  // LIB_ATSPI_ATSPI_NODE_H_

--- a/include/acacia/atspi/atspi_table_cell_interface.h
+++ b/include/acacia/atspi/atspi_table_cell_interface.h
@@ -5,6 +5,8 @@
 
 #include <atspi/atspi.h>
 
+namespace acacia {
+
 /**
  * This object wraps an
  * [AtspiTableCell](https://docs.gtk.org/atspi2/iface.TableCell.html) pointer.
@@ -72,5 +74,7 @@ class AtspiTableCellInterface {
    */
   int getRowSpan() const;
 };
+
+}  // namespace acacia
 
 #endif  // LIB_ATSPI_ATSPI_TABLE_CELL_H_

--- a/include/acacia/atspi/atspi_table_interface.h
+++ b/include/acacia/atspi/atspi_table_interface.h
@@ -5,6 +5,8 @@
 
 #include <atspi/atspi.h>
 
+namespace acacia {
+
 /**
  * This object wraps an
  * [AtspiTable](https://docs.gtk.org/atspi2/iface.Table.html) pointer. It can be
@@ -49,5 +51,7 @@ class AtspiTableInterface {
    */
   int getNRows() const;
 };
+
+}  // namespace acacia
 
 #endif  // LIB_ATSPI_ATSPI_TABLE_H_

--- a/include/acacia/atspi/atspi_text_interface.h
+++ b/include/acacia/atspi/atspi_text_interface.h
@@ -5,6 +5,8 @@
 
 #include <atspi/atspi.h>
 
+namespace acacia {
+
 /**
  * This object wraps an
  * [AtspiText](https://docs.gtk.org/atspi2/iface.Text.html) pointer. It can be
@@ -59,5 +61,7 @@ class AtspiTextInterface {
    */
   std::string getText(int start_offset, int end_offset) const;
 };
+
+}  // namespace acacia
 
 #endif  // LIB_ATSPI_ATSPI_TEXT_H_

--- a/include/acacia/atspi/atspi_value_interface.h
+++ b/include/acacia/atspi/atspi_value_interface.h
@@ -5,6 +5,8 @@
 
 #include <atspi/atspi.h>
 
+namespace acacia {
+
 /**
  * This object wraps an
  * [AtspiValue](https://docs.gtk.org/atspi2/iface.Value.html) pointer. It can be
@@ -56,5 +58,7 @@ class AtspiValueInterface {
    */
   double getMinimumValue() const;
 };
+
+}  // namespace acacia
 
 #endif  // LIB_ATSPI_ATSPI_VALUE_H_

--- a/include/acacia/atspi/linux_utils.h
+++ b/include/acacia/atspi/linux_utils.h
@@ -12,6 +12,8 @@
  */
 /** @} */  // end of atspi group
 
+namespace acacia {
+
 /**
  * Returns the root node of the accessible tree of a running application
  * referenced by pid.
@@ -38,5 +40,7 @@ AtspiNode findRootAtspiNodeForPID(const int pid);
  * exists.
  */
 AtspiNode findRootAtspiNodeForName(const std::string& name, const int pid = 0);
+
+}  // namespace acacia
 
 #endif  // LIB_ATSPI_LINUX_UTILS_H_

--- a/lib/atspi/acacia_atspi.i
+++ b/lib/atspi/acacia_atspi.i
@@ -19,77 +19,77 @@
 %include <std_vector.i>
 
 namespace std {
-  %template(AtspiNodeVector) vector<AtspiNode>;
+  %template(AtspiNodeVector) vector<acacia::AtspiNode>;
   %template(AtspiStringVector) vector<std::string>;
   %template(AtspiPairIntInt) pair<int, int>;
 };
 
-%catches(std::runtime_error) AtspiNode::getRoleName() const;
-%catches(std::runtime_error) AtspiNode::getName() const;
-%catches(std::runtime_error) AtspiNode::getDescription() const;
-%catches(std::runtime_error) AtspiNode::getAttributes() const;
-%catches(std::runtime_error) AtspiNode::getInterfaces() const;
-%catches(std::runtime_error) AtspiNode::getRelations() const;
-%catches(std::runtime_error) AtspiNode::getTargetForRelationAtIndex(int relation_index, int target_index) const;
-%catches(std::runtime_error) AtspiNode::getStates() const;
-%catches(std::runtime_error) AtspiNode::getChildCount() const;
-%catches(std::runtime_error) AtspiNode::getChildAtIndex(int index) const;
-%catches(std::runtime_error) AtspiNode::getChildren() const;
-%catches(std::runtime_error) AtspiNode::queryAction() const;
-%catches(std::runtime_error) AtspiNode::queryComponent() const;
-%catches(std::runtime_error) AtspiNode::queryDocument() const;
-%catches(std::runtime_error) AtspiNode::queryHyperlink() const;
-%catches(std::runtime_error) AtspiNode::queryTable() const;
-%catches(std::runtime_error) AtspiNode::queryTableCell() const;
-%catches(std::runtime_error) AtspiNode::queryText() const;
-%catches(std::runtime_error) AtspiNode::queryValue() const;
+%catches(std::runtime_error) acacia::AtspiNode::getRoleName() const;
+%catches(std::runtime_error) acacia::AtspiNode::getName() const;
+%catches(std::runtime_error) acacia::AtspiNode::getDescription() const;
+%catches(std::runtime_error) acacia::AtspiNode::getAttributes() const;
+%catches(std::runtime_error) acacia::AtspiNode::getInterfaces() const;
+%catches(std::runtime_error) acacia::AtspiNode::getRelations() const;
+%catches(std::runtime_error) acacia::AtspiNode::getTargetForRelationAtIndex(int relation_index, int target_index) const;
+%catches(std::runtime_error) acacia::AtspiNode::getStates() const;
+%catches(std::runtime_error) acacia::AtspiNode::getChildCount() const;
+%catches(std::runtime_error) acacia::AtspiNode::getChildAtIndex(int index) const;
+%catches(std::runtime_error) acacia::AtspiNode::getChildren() const;
+%catches(std::runtime_error) acacia::AtspiNode::queryAction() const;
+%catches(std::runtime_error) acacia::AtspiNode::queryComponent() const;
+%catches(std::runtime_error) acacia::AtspiNode::queryDocument() const;
+%catches(std::runtime_error) acacia::AtspiNode::queryHyperlink() const;
+%catches(std::runtime_error) acacia::AtspiNode::queryTable() const;
+%catches(std::runtime_error) acacia::AtspiNode::queryTableCell() const;
+%catches(std::runtime_error) acacia::AtspiNode::queryText() const;
+%catches(std::runtime_error) acacia::AtspiNode::queryValue() const;
 
-%catches(std::runtime_error) AtspiActionInterface::isNull() const;
-%catches(std::runtime_error) AtspiActionInterface::toString() const;
-%catches(std::runtime_error) AtspiActionInterface::getNActions() const;
-%catches(std::runtime_error) AtspiActionInterface::getName(int index) const;
-%catches(std::runtime_error) AtspiActionInterface::getDescription(int index) const;
+%catches(std::runtime_error) acacia::AtspiActionInterface::isNull() const;
+%catches(std::runtime_error) acacia::AtspiActionInterface::toString() const;
+%catches(std::runtime_error) acacia::AtspiActionInterface::getNActions() const;
+%catches(std::runtime_error) acacia::AtspiActionInterface::getName(int index) const;
+%catches(std::runtime_error) acacia::AtspiActionInterface::getDescription(int index) const;
 
-%catches(std::runtime_error) AtspiComponentInterface::isNull() const;
-%catches(std::runtime_error) AtspiComponentInterface::toString() const;
-%catches(std::runtime_error) AtspiComponentInterface::getPosition() const;
-%catches(std::runtime_error) AtspiComponentInterface::getSize() const;
+%catches(std::runtime_error) acacia::AtspiComponentInterface::isNull() const;
+%catches(std::runtime_error) acacia::AtspiComponentInterface::toString() const;
+%catches(std::runtime_error) acacia::AtspiComponentInterface::getPosition() const;
+%catches(std::runtime_error) acacia::AtspiComponentInterface::getSize() const;
 
-%catches(std::runtime_error) AtspiDocumentInterface::isNull() const;
-%catches(std::runtime_error) AtspiDocumentInterface::toString() const;
-%catches(std::runtime_error) AtspiDocumentInterface::getDocumentAttributes() const;
-%catches(std::runtime_error) AtspiDocumentInterface::getLocale() const;
+%catches(std::runtime_error) acacia::AtspiDocumentInterface::isNull() const;
+%catches(std::runtime_error) acacia::AtspiDocumentInterface::toString() const;
+%catches(std::runtime_error) acacia::AtspiDocumentInterface::getDocumentAttributes() const;
+%catches(std::runtime_error) acacia::AtspiDocumentInterface::getLocale() const;
 
-%catches(std::runtime_error) AtspiHyperlinkInterface::isNull() const;
-%catches(std::runtime_error) AtspiHyperlinkInterface::toString() const;
-%catches(std::runtime_error) AtspiHyperlinkInterface::getStartIndex() const;
-%catches(std::runtime_error) AtspiHyperlinkInterface::getEndIndex() const;
-%catches(std::runtime_error) AtspiHyperlinkInterface::getURI(int index) const;
+%catches(std::runtime_error) acacia::AtspiHyperlinkInterface::isNull() const;
+%catches(std::runtime_error) acacia::AtspiHyperlinkInterface::toString() const;
+%catches(std::runtime_error) acacia::AtspiHyperlinkInterface::getStartIndex() const;
+%catches(std::runtime_error) acacia::AtspiHyperlinkInterface::getEndIndex() const;
+%catches(std::runtime_error) acacia::AtspiHyperlinkInterface::getURI(int index) const;
 
-%catches(std::runtime_error) AtspiTableInterface::isNull() const;
-%catches(std::runtime_error) AtspiTableInterface::toString() const;
-%catches(std::runtime_error) AtspiTableInterface::getNColumns() const;
-%catches(std::runtime_error) AtspiTableInterface::getNRows() const;
+%catches(std::runtime_error) acacia::AtspiTableInterface::isNull() const;
+%catches(std::runtime_error) acacia::AtspiTableInterface::toString() const;
+%catches(std::runtime_error) acacia::AtspiTableInterface::getNColumns() const;
+%catches(std::runtime_error) acacia::AtspiTableInterface::getNRows() const;
 
-%catches(std::runtime_error) AtspiTextInterface::isNull() const;
-%catches(std::runtime_error) AtspiTextInterface::toString() const;
-%catches(std::runtime_error) AtspiTextInterface::getCaretOffset() const;
-%catches(std::runtime_error) AtspiTextInterface::getCharacterCount() const;
-%catches(std::runtime_error) AtspiTextInterface::getText(int start_offset, int end_offset) const;
+%catches(std::runtime_error) acacia::AtspiTextInterface::isNull() const;
+%catches(std::runtime_error) acacia::AtspiTextInterface::toString() const;
+%catches(std::runtime_error) acacia::AtspiTextInterface::getCaretOffset() const;
+%catches(std::runtime_error) acacia::AtspiTextInterface::getCharacterCount() const;
+%catches(std::runtime_error) acacia::AtspiTextInterface::getText(int start_offset, int end_offset) const;
 
-%catches(std::runtime_error) AtspiTableCellInterface::isNull() const;
-%catches(std::runtime_error) AtspiTableCellInterface::toString() const;
-%catches(std::runtime_error) AtspiTableCellInterface::getPosition() const;
-%catches(std::runtime_error) AtspiTableCellInterface::getColumnIndex() const;
-%catches(std::runtime_error) AtspiTableCellInterface::getColumnSpan() const;
-%catches(std::runtime_error) AtspiTableCellInterface::getRowIndex() const;
-%catches(std::runtime_error) AtspiTableCellInterface::getRowSpan() const;
+%catches(std::runtime_error) acacia::AtspiTableCellInterface::isNull() const;
+%catches(std::runtime_error) acacia::AtspiTableCellInterface::toString() const;
+%catches(std::runtime_error) acacia::AtspiTableCellInterface::getPosition() const;
+%catches(std::runtime_error) acacia::AtspiTableCellInterface::getColumnIndex() const;
+%catches(std::runtime_error) acacia::AtspiTableCellInterface::getColumnSpan() const;
+%catches(std::runtime_error) acacia::AtspiTableCellInterface::getRowIndex() const;
+%catches(std::runtime_error) acacia::AtspiTableCellInterface::getRowSpan() const;
 
-%catches(std::runtime_error) AtspiValueInterface::isNull() const;
-%catches(std::runtime_error) AtspiValueInterface::toString() const;
-%catches(std::runtime_error) AtspiValueInterface::getCurrentValue() const;
-%catches(std::runtime_error) AtspiValueInterface::getMaximumValue() const;
-%catches(std::runtime_error) AtspiValueInterface::getMinimumValue() const;
+%catches(std::runtime_error) acacia::AtspiValueInterface::isNull() const;
+%catches(std::runtime_error) acacia::AtspiValueInterface::toString() const;
+%catches(std::runtime_error) acacia::AtspiValueInterface::getCurrentValue() const;
+%catches(std::runtime_error) acacia::AtspiValueInterface::getMaximumValue() const;
+%catches(std::runtime_error) acacia::AtspiValueInterface::getMinimumValue() const;
 
 %include <acacia/atspi/atspi_action_interface.h>
 %include <acacia/atspi/atspi_component_interface.h>

--- a/lib/atspi/acacia_atspi.i
+++ b/lib/atspi/acacia_atspi.i
@@ -10,6 +10,8 @@
 #include <acacia/atspi/atspi_text_interface.h>
 #include <acacia/atspi/atspi_value_interface.h>
 #include <acacia/atspi/linux_utils.h>
+
+using namespace acacia;
 %}
 
 %include <std_except.i>
@@ -95,9 +97,9 @@ namespace std {
 %include <acacia/atspi/atspi_component_interface.h>
 %include <acacia/atspi/atspi_document_interface.h>
 %include <acacia/atspi/atspi_hyperlink_interface.h>
-%include <acacia/atspi/atspi_node.h>
 %include <acacia/atspi/atspi_table_interface.h>
 %include <acacia/atspi/atspi_table_cell_interface.h>
 %include <acacia/atspi/atspi_text_interface.h>
 %include <acacia/atspi/atspi_value_interface.h>
+%include <acacia/atspi/atspi_node.h>
 %include <acacia/atspi/linux_utils.h>

--- a/lib/atspi/atspi_action_interface.cc
+++ b/lib/atspi/atspi_action_interface.cc
@@ -8,6 +8,8 @@
 
 #include "../utils.h"
 
+namespace acacia {
+
 std::string AtspiActionInterface::toString() const {
   if (isNull())
     return "Not implemented";
@@ -65,3 +67,5 @@ std::string AtspiActionInterface::getDescription(int index) const {
   g_free(description);
   return result;
 }
+
+}  // namespace acacia

--- a/lib/atspi/atspi_component_interface.cc
+++ b/lib/atspi/atspi_component_interface.cc
@@ -6,6 +6,8 @@
 #include <stdexcept>
 #include <string>
 
+namespace acacia {
+
 std::string AtspiComponentInterface::toString() const {
   if (isNull())
     return "Not implemented";
@@ -56,3 +58,5 @@ std::pair<int, int> AtspiComponentInterface::getSize() const {
   g_free(size);
   return result;
 }
+
+}  // namespace acacia

--- a/lib/atspi/atspi_document_interface.cc
+++ b/lib/atspi/atspi_document_interface.cc
@@ -7,6 +7,8 @@
 
 #include "../utils.h"
 
+namespace acacia {
+
 std::string AtspiDocumentInterface::toString() const {
   if (isNull())
     return "Not implemented";
@@ -54,3 +56,5 @@ std::string AtspiDocumentInterface::getLocale() const {
   g_free(locale);
   return result;
 }
+
+}  // namespace acacia

--- a/lib/atspi/atspi_hyperlink_interface.cc
+++ b/lib/atspi/atspi_hyperlink_interface.cc
@@ -5,6 +5,8 @@
 #include <stdexcept>
 #include <string>
 
+namespace acacia {
+
 std::string AtspiHyperlinkInterface::toString() const {
   if (isNull()) {
     return "Not implemented";
@@ -60,3 +62,5 @@ std::string AtspiHyperlinkInterface::getURI(int index) const {
   g_free(uri);
   return result;
 }
+
+}  // namespace acacia

--- a/lib/atspi/atspi_node.cc
+++ b/lib/atspi/atspi_node.cc
@@ -158,6 +158,8 @@ static const std::string RelationTypeToString(
 
 }  // Namespace
 
+namespace acacia {
+
 bool AtspiNode::isNull() const {
   return accessible_ == NULL;
 }
@@ -440,3 +442,5 @@ AtspiValueInterface AtspiNode::queryValue() const {
 
   return AtspiValueInterface();
 }
+
+}  // namespace acacia

--- a/lib/atspi/atspi_table_cell_interface.cc
+++ b/lib/atspi/atspi_table_cell_interface.cc
@@ -5,6 +5,8 @@
 #include <stdexcept>
 #include <string>
 
+namespace acacia {
+
 std::string AtspiTableCellInterface::toString() const {
   if (isNull())
     return "Not implemented";
@@ -65,3 +67,5 @@ int AtspiTableCellInterface::getRowSpan() const {
   }
   return result;
 }
+
+}  // namespace acacia

--- a/lib/atspi/atspi_table_interface.cc
+++ b/lib/atspi/atspi_table_interface.cc
@@ -5,6 +5,8 @@
 #include <stdexcept>
 #include <string>
 
+namespace acacia {
+
 std::string AtspiTableInterface::toString() const {
   if (isNull())
     return "Not implemented";
@@ -40,3 +42,5 @@ int AtspiTableInterface::getNRows() const {
   }
   return result;
 }
+
+}  // namespace acacia

--- a/lib/atspi/atspi_text_interface.cc
+++ b/lib/atspi/atspi_text_interface.cc
@@ -5,6 +5,8 @@
 #include <stdexcept>
 #include <string>
 
+namespace acacia {
+
 static std::string ToPrintableString(std::string str) {
   const std::string ufffc = "\xEF\xBF\xBC";
   const std::string printable_ufffc = "[obj]";
@@ -77,3 +79,5 @@ std::string AtspiTextInterface::getText(int start_offset,
   g_free(text);
   return result;
 }
+
+}  // namespace acacia

--- a/lib/atspi/atspi_value_interface.cc
+++ b/lib/atspi/atspi_value_interface.cc
@@ -5,6 +5,8 @@
 #include <stdexcept>
 #include <string>
 
+namespace acacia {
+
 std::string AtspiValueInterface::toString() const {
   if (isNull())
     return "Not implemented";
@@ -55,3 +57,5 @@ double AtspiValueInterface::getMinimumValue() const {
   }
   return result;
 }
+
+}  // namespace acacia

--- a/lib/atspi/linux_utils.cc
+++ b/lib/atspi/linux_utils.cc
@@ -6,6 +6,8 @@
 
 #include "../utils.h"
 
+namespace acacia {
+
 AtspiNode findRootAtspiNodeForPID(const int pid) {
   AtspiAccessible* desktop = atspi_get_desktop(0);
 
@@ -82,3 +84,5 @@ handle_gerror:
   g_error_free(error);
   throw std::runtime_error(err_msg);
 }
+
+}  // namespace acacia

--- a/tests/atspi/test_smoke.cc
+++ b/tests/atspi/test_smoke.cc
@@ -2,12 +2,12 @@
 #include <assert.h>
 
 int main(int argc, char** argv) {
-  AtspiNode root;
+  acacia::AtspiNode root;
 
   // @TODO: Just a smoke test to check-in unit tests infrastructure and
   // successful linking against AT-SPI backend libraries.
 
-  root = findRootAtspiNodeForName("_invalid_app_name_", 0);
+  root = acacia::findRootAtspiNodeForName("_invalid_app_name_", 0);
   assert(root.isNull());
 
   return 0;


### PR DESCRIPTION
Alice I tried to fit this one in before going on vacation -- but I'm getting errors when generating both nodejs and python binding:

```
../acacia_atspi_nodejs_wrap.cxx:4642:3: error: ‘AtspiTableInterface’ was not declared in this scope; did you mean ‘acacia::AtspiTableInterface’?
 4642 |   AtspiTableInterface result;
      |   ^~~~~~~~~~~~~~~~~~~
      |   acacia::AtspiTableInterface
```

I thought according to the SWIG does this should just work! Anyway, I'll look when I get back.