### PR TITLE
Make AtspiHyperlinkInterface use a raw pointer

### DIFF
--- a/include/acacia/atspi/atspi_hyperlink_interface.h
+++ b/include/acacia/atspi/atspi_hyperlink_interface.h
@@ -15,17 +15,14 @@
  */
 class AtspiHyperlinkInterface {
  public:
-  AtspiHyperlinkInterface(AtspiHyperlink* interface)
-      : interface_(interface,
-                   [](AtspiHyperlink* iface) { g_object_unref(iface); }){};
-  AtspiHyperlinkInterface()
-      : interface_(nullptr, [](AtspiHyperlink* iface) {}){};
-  ~AtspiHyperlinkInterface(){};
+  AtspiHyperlinkInterface(AtspiHyperlink* interface) : interface_(interface) {}
+  AtspiHyperlinkInterface(AtspiHyperlinkInterface&&);
+  AtspiHyperlinkInterface() = default;
+
+  ~AtspiHyperlinkInterface();
 
   AtspiHyperlinkInterface(const AtspiHyperlinkInterface&) = delete;
   AtspiHyperlinkInterface& operator=(const AtspiHyperlinkInterface&) = delete;
-
-  AtspiHyperlinkInterface(AtspiHyperlinkInterface&&) = default;
 
   /**
    * Tests whether the underlying AtspiHyperlink pointer is the null pointer.
@@ -70,7 +67,7 @@ class AtspiHyperlinkInterface {
   // then unrefing it in the destructor works with C++ but results in a double-
   // free with both python and node.
   // TODO: Find a way to use a raw pointer by modifying something in SWIG.
-  std::unique_ptr<AtspiHyperlink, void (*)(AtspiHyperlink*)> interface_;
+  AtspiHyperlink* interface_{nullptr};
 };
 
 #endif  // LIB_ATSPI_ATSPI_HYPERLINK_H_

--- a/lib/atspi/acacia_atspi.i
+++ b/lib/atspi/acacia_atspi.i
@@ -15,7 +15,6 @@
 %include <std_except.i>
 %include <std_pair.i>
 %include <std_string.i>
-%include <std_unique_ptr.i>
 %include <std_vector.i>
 
 namespace std {

--- a/lib/atspi/atspi_hyperlink_interface.cc
+++ b/lib/atspi/atspi_hyperlink_interface.cc
@@ -5,6 +5,18 @@
 #include <stdexcept>
 #include <string>
 
+AtspiHyperlinkInterface::~AtspiHyperlinkInterface() {
+  if (interface_)
+    g_object_unref(interface_);
+};
+
+AtspiHyperlinkInterface::AtspiHyperlinkInterface(
+    AtspiHyperlinkInterface&& other)
+    : interface_(other.interface_) {
+  // Move constructor: take ownership of interface_
+  other.interface_ = nullptr;
+}
+
 std::string AtspiHyperlinkInterface::toString() const {
   if (isNull()) {
     return "Not implemented";
@@ -20,7 +32,7 @@ int AtspiHyperlinkInterface::getStartIndex() const {
   }
 
   GError* error = nullptr;
-  double result = atspi_hyperlink_get_start_index(interface_.get(), &error);
+  double result = atspi_hyperlink_get_start_index(interface_, &error);
   if (error) {
     std::string err_msg = error->message;
     g_error_free(error);
@@ -35,7 +47,7 @@ int AtspiHyperlinkInterface::getEndIndex() const {
   }
 
   GError* error = nullptr;
-  double result = atspi_hyperlink_get_end_index(interface_.get(), &error);
+  double result = atspi_hyperlink_get_end_index(interface_, &error);
   if (error) {
     std::string err_msg = error->message;
     g_error_free(error);
@@ -50,7 +62,7 @@ std::string AtspiHyperlinkInterface::getURI(int index) const {
   }
 
   GError* error = nullptr;
-  char* uri = atspi_hyperlink_get_uri(interface_.get(), index, &error);
+  char* uri = atspi_hyperlink_get_uri(interface_, index, &error);
   if (error) {
     std::string err_msg = error->message;
     g_error_free(error);


### PR DESCRIPTION
The issue ended up being that the default move constructor was doing the right thing with the `unique_ptr`, but with a raw pointer we need to null out the moved pointer ourselves.