### PR TITLE
Fixing issues I had when trying to build on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ endif (ACACIA_DOCS)
 # We may decide to solve this problem differently in the future, or use
 # the bin for all executables across all platforms.
 if(WIN32)
-  set(WIN_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
+  set(WIN_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin/$<CONFIG>")
   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${WIN_OUTPUT_DIRECTORY}")
   set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${WIN_OUTPUT_DIRECTORY}")
 endif(WIN32)

--- a/lib/ia2/CMakeLists.txt
+++ b/lib/ia2/CMakeLists.txt
@@ -63,6 +63,8 @@ if (ACACIA_PYTHON)
     SOURCES acacia_ia2.i
     LANGUAGE python
     OUTPUT_DIR "${WIN_OUTPUT_DIRECTORY}"
+    # Output for the generated C++ wrapper
+    OUTFILE_DIR "${CMAKE_CURRENT_BINARY_DIR}"
   )
 
   TARGET_LINK_LIBRARIES(

--- a/lib/ia2/CMakeLists.txt
+++ b/lib/ia2/CMakeLists.txt
@@ -98,13 +98,18 @@ if (ACACIA_NODEJS)
   )
 
   add_custom_command(
+    TARGET acacia_ia2_node_module
+    POST_BUILD
+    COMMAND
+      ${CMAKE_COMMAND} -E copy "${NODE_GYP_OUTPUT_DIR}/acacia_ia2.node" "${WIN_OUTPUT_DIRECTORY}"
+  )
+
+  add_custom_command(
     OUTPUT acacia_ia2.node
     DEPENDS
     "${CMAKE_CURRENT_BINARY_DIR}/acacia_ia2_nodejs_wrap.cxx"
     COMMAND
       ${NODE_GYP} configure build
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${NODE_GYP_OUTPUT_DIR}/acacia_ia2.node" "${WIN_OUTPUT_DIRECTORY}"
-    VERBATIM
   )
 
   set_property(

--- a/lib/ia2/binding.gyp.in
+++ b/lib/ia2/binding.gyp.in
@@ -22,7 +22,7 @@
       'link_settings': {
         'libraries': [
           "oleacc.lib",
-          "${CMAKE_BINARY_DIR}/third_party/ia2/lib/iaccessible2.lib",
+          "${CMAKE_BINARY_DIR}/third_party/ia2/lib/Release/iaccessible2.lib",
         ]
       },
       "defines": [ "acacia_EXPORTS" ],


### PR DESCRIPTION
- The `WIN_OUTPUT_DIRECTORY` change is because some thing were ending up in `build/bin` and some things were ending up in `build/bin/Release`, but they all need to be in the same directory. This ensures that the VS Code generator doesn't get creative with adding `/Release` on the end of things. 
   - https://cmake.org/cmake/help/latest/prop_tgt/RUNTIME_OUTPUT_DIRECTORY.html notes "Multi-configuration generators (Visual Studio, Xcode, Ninja Multi-Config) append a per-configuration subdirectory to the specified directory **unless a generator expression is used**", so by using a generator expression here we can avoid the per-configuration sneakiness.
- The `OUTFILE_DIR` for the Python SWIG target is just because it was weird seeing `acacia_ia2PYTHON_wrap.cxx` end up in `build/bin` - I came across that while trying to fix the above actual problem
- The change in `binding.gyp.in` is a temporary fix for a related problem - `iaccessible2.lib` ends up in `build/third_party/ia2/lib/Release` for a Release build, because Visual Studio just tacks `Release` on the end. Obviously this fix won't work for a Debug build, but we're assuming `Release` elsewhere already, so we can fix them all at the same time whenever we fix #178.