### PR TITLE
Memory management improvements for Linux

### DIFF
--- a/include/acacia/atspi/atspi_action_interface.h
+++ b/include/acacia/atspi/atspi_action_interface.h
@@ -18,8 +18,7 @@ namespace acacia {
  */
 class AtspiActionInterface : public AtspiInterface<AtspiAction> {
  public:
-  using AtspiInterface::AtspiInterface;
-  using AtspiInterface::operator=;
+  using AtspiInterface<AtspiAction>::AtspiInterface;
 
   /**
    * Helper function to print commonly needed values associated with this

--- a/include/acacia/atspi/atspi_action_interface.h
+++ b/include/acacia/atspi/atspi_action_interface.h
@@ -1,6 +1,8 @@
 #ifndef INCLUDE_ACACIA_ATSPI_ATSPI_ACTION_INTERFACE_H_
 #define INCLUDE_ACACIA_ATSPI_ATSPI_ACTION_INTERFACE_H_
 
+#include "acacia/atspi/atspi_interface.h"
+
 #include <string>
 
 #include <atspi/atspi.h>
@@ -14,28 +16,17 @@ namespace acacia {
  * AtspiNode::queryAction().
  * @ingroup atspi
  */
-class AtspiActionInterface {
-  AtspiAction* interface_;
-
+class AtspiActionInterface : public AtspiInterface<AtspiAction> {
  public:
-  AtspiActionInterface(AtspiAction* interface) : interface_(interface){};
-  AtspiActionInterface() : interface_(nullptr){};
-  ~AtspiActionInterface(){};
-
-  /**
-   * Tests whether the underlying AtspiAction pointer is the null pointer. An
-   * AtspiActionInterface with an null AtspiAction pointer will be created if
-   * the wrapped API returned a nullptr with no error codes.
-   * @ingroup atspi
-   */
-  bool isNull() const { return !interface_; }
+  using AtspiInterface::AtspiInterface;
+  using AtspiInterface::operator=;
 
   /**
    * Helper function to print commonly needed values associated with this
    * interface.
    * @ingroup atspi
    */
-  std::string toString() const;
+  std::string toString() const override;
 
   /**
    * Wraps

--- a/include/acacia/atspi/atspi_component_interface.h
+++ b/include/acacia/atspi/atspi_component_interface.h
@@ -19,7 +19,6 @@ namespace acacia {
 class AtspiComponentInterface : public AtspiInterface<AtspiComponent> {
  public:
   using AtspiInterface::AtspiInterface;
-  using AtspiInterface::operator=;
 
   /**
    * Helper function to print commonly needed values associated with this

--- a/include/acacia/atspi/atspi_component_interface.h
+++ b/include/acacia/atspi/atspi_component_interface.h
@@ -1,6 +1,8 @@
 #ifndef INCLUDE_ACACIA_ATSPI_ATSPI_COMPONENT_INTERFACE_H_
 #define INCLUDE_ACACIA_ATSPI_ATSPI_COMPONENT_INTERFACE_H_
 
+#include "acacia/atspi/atspi_interface.h"
+
 #include <string>
 
 #include <atspi/atspi.h>
@@ -14,28 +16,17 @@ namespace acacia {
  * using AtspiNode::queryComponent().
  * @ingroup atspi
  */
-class AtspiComponentInterface {
-  AtspiComponent* interface_;
-
+class AtspiComponentInterface : public AtspiInterface<AtspiComponent> {
  public:
-  AtspiComponentInterface(AtspiComponent* interface) : interface_(interface){};
-  AtspiComponentInterface() : interface_(nullptr){};
-  ~AtspiComponentInterface(){};
-
-  /**
-   * Tests whether the underlying AtspiComponent pointer is the null pointer. An
-   * AtspiComponentInterface with an null AtspiComponent pointer will be created
-   * if the wrapped API returned a nullptr with no error codes.
-   * @ingroup atspi
-   */
-  bool isNull() const { return !interface_; }
+  using AtspiInterface::AtspiInterface;
+  using AtspiInterface::operator=;
 
   /**
    * Helper function to print commonly needed values associated with this
    * interface.
    * @ingroup atspi
    */
-  std::string toString() const;
+  std::string toString() const override;
 
   /**
    * Wraps

--- a/include/acacia/atspi/atspi_document_interface.h
+++ b/include/acacia/atspi/atspi_document_interface.h
@@ -1,6 +1,8 @@
 #ifndef INCLUDE_ACACIA_ATSPI_ATSPI_DOCUMENT_INTERFACE_H_
 #define INCLUDE_ACACIA_ATSPI_ATSPI_DOCUMENT_INTERFACE_H_
 
+#include "acacia/atspi/atspi_interface.h"
+
 #include <string>
 #include <vector>
 
@@ -15,28 +17,17 @@ namespace acacia {
  * using AtspiNode::queryDocument().
  * @ingroup atspi
  */
-class AtspiDocumentInterface {
-  AtspiDocument* interface_;
-
+class AtspiDocumentInterface : public AtspiInterface<AtspiDocument> {
  public:
-  AtspiDocumentInterface(AtspiDocument* interface) : interface_(interface){};
-  AtspiDocumentInterface() : interface_(nullptr){};
-  ~AtspiDocumentInterface(){};
-
-  /**
-   * Tests whether the underlying AtspiDocument pointer is the null pointer. An
-   * AtspiDocumentInterface with an null AtspiDocument pointer will be created
-   * if the wrapped API returned a nullptr with no error codes.
-   * @ingroup atspi
-   */
-  bool isNull() const { return !interface_; }
+  using AtspiInterface::AtspiInterface;
+  using AtspiInterface::operator=;
 
   /**
    * Helper function to print commonly needed values associated with this
    * interface.
    * @ingroup atspi
    */
-  std::string toString() const;
+  std::string toString() const override;
 
   /**
    * Wraps

--- a/include/acacia/atspi/atspi_document_interface.h
+++ b/include/acacia/atspi/atspi_document_interface.h
@@ -19,8 +19,7 @@ namespace acacia {
  */
 class AtspiDocumentInterface : public AtspiInterface<AtspiDocument> {
  public:
-  using AtspiInterface::AtspiInterface;
-  using AtspiInterface::operator=;
+  using AtspiInterface<AtspiDocument>::AtspiInterface;
 
   /**
    * Helper function to print commonly needed values associated with this

--- a/include/acacia/atspi/atspi_hyperlink_interface.h
+++ b/include/acacia/atspi/atspi_hyperlink_interface.h
@@ -1,10 +1,10 @@
 #ifndef INCLUDE_ACACIA_ATSPI_ATSPI_HYPERLINK_INTERFACE_H_
 #define INCLUDE_ACACIA_ATSPI_ATSPI_HYPERLINK_INTERFACE_H_
 
+#include "acacia/atspi/atspi_interface.h"
+
 #include <memory>
 #include <string>
-
-#include <atspi/atspi.h>
 
 namespace acacia {
 
@@ -15,32 +15,17 @@ namespace acacia {
  * using AtspiNode::queryHyperlink().
  * @ingroup atspi
  */
-class AtspiHyperlinkInterface {
+class AtspiHyperlinkInterface : public AtspiInterface<AtspiHyperlink> {
  public:
-  AtspiHyperlinkInterface(AtspiHyperlink* interface)
-      : interface_(interface,
-                   [](AtspiHyperlink* iface) { g_object_unref(iface); }){};
-  AtspiHyperlinkInterface()
-      : interface_(nullptr, [](AtspiHyperlink* iface) {}){};
-  ~AtspiHyperlinkInterface(){};
-
-  AtspiHyperlinkInterface(const AtspiHyperlinkInterface&) = delete;
-  AtspiHyperlinkInterface& operator=(const AtspiHyperlinkInterface&) = delete;
-
-  AtspiHyperlinkInterface(AtspiHyperlinkInterface&&) = default;
-
-  /**
-   * Tests whether the underlying AtspiHyperlink pointer is the null pointer.
-   * @ingroup atspi
-   */
-  bool isNull() const { return !interface_; }
+  using AtspiInterface::AtspiInterface;
+  using AtspiInterface::operator=;
 
   /**
    * Helper function to print commonly needed values associated with this
    * interface.
    * @ingroup atspi
    */
-  std::string toString() const;
+  std::string toString() const override;
 
   /**
    * Wraps
@@ -64,15 +49,6 @@ class AtspiHyperlinkInterface {
    * @param index: Indiciates which hyperlink anchor to query.
    */
   std::string getURI(int index = 0) const;
-
- private:
-  // We use a smart pointer here: `atspi_accessible_get_hyperlink` returns a
-  // new hyperlink object rather than increasing the ref count and casting the
-  // the AtspiAccessible as the interface. Keeping this as a raw pointer and
-  // then unrefing it in the destructor works with C++ but results in a double-
-  // free with both python and node.
-  // TODO: Find a way to use a raw pointer by modifying something in SWIG.
-  std::unique_ptr<AtspiHyperlink, void (*)(AtspiHyperlink*)> interface_;
 };
 
 }  // namespace acacia

--- a/include/acacia/atspi/atspi_hyperlink_interface.h
+++ b/include/acacia/atspi/atspi_hyperlink_interface.h
@@ -17,8 +17,7 @@ namespace acacia {
  */
 class AtspiHyperlinkInterface : public AtspiInterface<AtspiHyperlink> {
  public:
-  using AtspiInterface::AtspiInterface;
-  using AtspiInterface::operator=;
+  using AtspiInterface<AtspiHyperlink>::AtspiInterface;
 
   /**
    * Helper function to print commonly needed values associated with this

--- a/include/acacia/atspi/atspi_interface.h
+++ b/include/acacia/atspi/atspi_interface.h
@@ -1,0 +1,51 @@
+#ifndef INCLUDE_ACACIA_ATSPI_ATSPI_INTERFACE_H_
+#define INCLUDE_ACACIA_ATSPI_ATSPI_INTERFACE_H_
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <atspi/atspi.h>
+
+namespace acacia {
+
+/**
+ * Objects descending from this class wrap an
+ * [AtspiObject](https://docs.gtk.org/atspi2/class.Object.html) of a specific
+ * type. See descendants of this class for more information about each type.
+ */
+template <typename T>
+class AtspiInterface {
+ public:
+  explicit AtspiInterface(T* interface) : interface_(interface, Deleter()) {}
+
+  AtspiInterface() {}
+  virtual ~AtspiInterface() {}
+
+  /**
+   * Tests whether the underlying interface pointer is null.
+   */
+  bool isNull() const { return !interface_; }
+
+  /**
+   * Helper function to print commonly needed values associated with this
+   * interface.
+   */
+  virtual std::string toString() const = 0;
+
+ protected:
+  class Deleter {
+   public:
+    void operator()(T* ptr) {
+      if (ptr == nullptr)
+        return;
+      g_object_unref(ptr);
+    }
+  };
+
+  std::shared_ptr<T> interface_{nullptr};
+};
+
+}  // namespace acacia
+
+#endif  // INCLUDE_ACACIA_ATSPI_ATSPI_INTERFACE_H_

--- a/include/acacia/atspi/atspi_node.h
+++ b/include/acacia/atspi/atspi_node.h
@@ -1,10 +1,12 @@
 #ifndef INCLUDE_ACACIA_ATSPI_ATSPI_NODE_H_
 #define INCLUDE_ACACIA_ATSPI_ATSPI_NODE_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 
 #include <atspi/atspi.h>
+#include <glib.h>
 
 #include "acacia/atspi/atspi_action_interface.h"
 #include "acacia/atspi/atspi_component_interface.h"
@@ -23,17 +25,15 @@ namespace acacia {
  * @ingroup atspi
  */
 class AtspiNode {
-  AtspiAccessible* accessible_;
-
  public:
-  AtspiNode(AtspiAccessible* accessible) : accessible_(accessible){};
-  AtspiNode() : accessible_(nullptr){};
-  ~AtspiNode(){};
+  AtspiNode(AtspiAccessible* accessible) : accessible_(accessible, Deleter()) {}
+  AtspiNode() = default;
+  ~AtspiNode() = default;
 
   /**
-   * Tests whether the underlying AtspiAccessible pointer is the null pointer.
-   * An AtspiNode with an null AtspiAccessible pointer will be created if the
-   * wrapped API returned a nullptr with no error codes.
+   * Tests whether the underlying AtspiAccessible pointer is the null
+   * pointer. An AtspiNode with an null AtspiAccessible pointer will be
+   * created if the wrapped API returned a nullptr with no error codes.
    * @ingroup atspi
    */
   bool isNull() const;
@@ -210,6 +210,18 @@ class AtspiNode {
    * @returns An @ref AtspiValueInterface.
    */
   AtspiValueInterface queryValue() const;
+
+ private:
+  class Deleter {
+   public:
+    void operator()(AtspiAccessible* ptr) {
+      if (ptr == nullptr)
+        return;
+      g_object_unref(ptr);
+    }
+  };
+
+  std::shared_ptr<AtspiAccessible> accessible_;
 };
 
 }  // namespace acacia

--- a/include/acacia/atspi/atspi_table_cell_interface.h
+++ b/include/acacia/atspi/atspi_table_cell_interface.h
@@ -1,6 +1,8 @@
 #ifndef INCLUDE_ACACIA_ATSPI_ATSPI_TABLE_CELL_INTERFACE_H_
 #define INCLUDE_ACACIA_ATSPI_ATSPI_TABLE_CELL_INTERFACE_H_
 
+#include "acacia/atspi/atspi_interface.h"
+
 #include <string>
 
 #include <atspi/atspi.h>
@@ -14,28 +16,17 @@ namespace acacia {
  * using AtspiNode::queryTableCell().
  * @ingroup atspi
  */
-class AtspiTableCellInterface {
-  AtspiTableCell* interface_;
-
+class AtspiTableCellInterface : public AtspiInterface<AtspiTableCell> {
  public:
-  AtspiTableCellInterface(AtspiTableCell* interface) : interface_(interface){};
-  AtspiTableCellInterface() : interface_(nullptr){};
-  ~AtspiTableCellInterface(){};
-
-  /**
-   * Tests whether the underlying AtspiTableCell pointer is the null pointer. An
-   * AtspiTableCellInterface with an null AtspiTableCell pointer will be created
-   * if the wrapped API returned a nullptr with no error codes.
-   * @ingroup atspi
-   */
-  bool isNull() const { return !interface_; }
+  using AtspiInterface::AtspiInterface;
+  using AtspiInterface::operator=;
 
   /**
    * Helper function to print commonly needed values associated with this
    * interface.
    * @ingroup atspi
    */
-  std::string toString() const;
+  std::string toString() const override;
 
   /**
    * Wraps

--- a/include/acacia/atspi/atspi_table_cell_interface.h
+++ b/include/acacia/atspi/atspi_table_cell_interface.h
@@ -18,8 +18,7 @@ namespace acacia {
  */
 class AtspiTableCellInterface : public AtspiInterface<AtspiTableCell> {
  public:
-  using AtspiInterface::AtspiInterface;
-  using AtspiInterface::operator=;
+  using AtspiInterface<AtspiTableCell>::AtspiInterface;
 
   /**
    * Helper function to print commonly needed values associated with this

--- a/include/acacia/atspi/atspi_table_interface.h
+++ b/include/acacia/atspi/atspi_table_interface.h
@@ -1,6 +1,8 @@
 #ifndef INCLUDE_ACACIA_ATSPI_ATSPI_TABLE_INTERFACE_H_
 #define INCLUDE_ACACIA_ATSPI_ATSPI_TABLE_INTERFACE_H_
 
+#include "acacia/atspi/atspi_interface.h"
+
 #include <string>
 
 #include <atspi/atspi.h>
@@ -14,28 +16,17 @@ namespace acacia {
  * AtspiNode::queryTable().
  * @ingroup atspi
  */
-class AtspiTableInterface {
-  AtspiTable* interface_;
-
+class AtspiTableInterface : public AtspiInterface<AtspiTable> {
  public:
-  AtspiTableInterface(AtspiTable* interface) : interface_(interface){};
-  AtspiTableInterface() : interface_(nullptr){};
-  ~AtspiTableInterface(){};
-
-  /**
-   * Tests whether the underlying AtspiTable pointer is the null pointer. An
-   * AtspiTableInterface with an null AtspiTable pointer will be created if the
-   * wrapped API returned a nullptr with no error codes.
-   * @ingroup atspi
-   */
-  bool isNull() const { return !interface_; }
+  using AtspiInterface::AtspiInterface;
+  using AtspiInterface::operator=;
 
   /**
    * Helper function to print commonly needed values associated with this
    * interface.
    * @ingroup atspi
    */
-  std::string toString() const;
+  std::string toString() const override;
 
   /**
    * Wraps

--- a/include/acacia/atspi/atspi_table_interface.h
+++ b/include/acacia/atspi/atspi_table_interface.h
@@ -18,8 +18,7 @@ namespace acacia {
  */
 class AtspiTableInterface : public AtspiInterface<AtspiTable> {
  public:
-  using AtspiInterface::AtspiInterface;
-  using AtspiInterface::operator=;
+  using AtspiInterface<AtspiTable>::AtspiInterface;
 
   /**
    * Helper function to print commonly needed values associated with this

--- a/include/acacia/atspi/atspi_text_interface.h
+++ b/include/acacia/atspi/atspi_text_interface.h
@@ -1,6 +1,8 @@
 #ifndef INCLUDE_ACACIA_ATSPI_ATSPI_TEXT_INTERFACE_H_
 #define INCLUDE_ACACIA_ATSPI_ATSPI_TEXT_INTERFACE_H_
 
+#include "acacia/atspi/atspi_interface.h"
+
 #include <string>
 
 #include <atspi/atspi.h>
@@ -14,28 +16,17 @@ namespace acacia {
  * AtspiNode::queryText().
  * @ingroup atspi
  */
-class AtspiTextInterface {
-  AtspiText* interface_;
-
+class AtspiTextInterface : public AtspiInterface<AtspiText> {
  public:
-  AtspiTextInterface(AtspiText* interface) : interface_(interface){};
-  AtspiTextInterface() : interface_(nullptr){};
-  ~AtspiTextInterface(){};
-
-  /**
-   * Tests whether the underlying AtspiText pointer is the null pointer. An
-   * AtspiTextInterface with an null AtspiText pointer will be created if the
-   * wrapped API returned a nullptr with no error codes.
-   * @ingroup atspi
-   */
-  bool isNull() const { return !interface_; }
+  using AtspiInterface::AtspiInterface;
+  using AtspiInterface::operator=;
 
   /**
    * Helper function to print commonly needed values associated with this
    * interface.
    * @ingroup atspi
    */
-  std::string toString() const;
+  std::string toString() const override;
 
   /**
    * Wraps

--- a/include/acacia/atspi/atspi_text_interface.h
+++ b/include/acacia/atspi/atspi_text_interface.h
@@ -18,8 +18,7 @@ namespace acacia {
  */
 class AtspiTextInterface : public AtspiInterface<AtspiText> {
  public:
-  using AtspiInterface::AtspiInterface;
-  using AtspiInterface::operator=;
+  using AtspiInterface<AtspiText>::AtspiInterface;
 
   /**
    * Helper function to print commonly needed values associated with this

--- a/include/acacia/atspi/atspi_value_interface.h
+++ b/include/acacia/atspi/atspi_value_interface.h
@@ -1,6 +1,8 @@
 #ifndef INCLUDE_ACACIA_ATSPI_ATSPI_VALUE_INTERFACE_H_
 #define INCLUDE_ACACIA_ATSPI_ATSPI_VALUE_INTERFACE_H_
 
+#include "acacia/atspi/atspi_interface.h"
+
 #include <string>
 
 #include <atspi/atspi.h>
@@ -14,28 +16,17 @@ namespace acacia {
  * AtspiNode::queryValue().
  * @ingroup atspi
  */
-class AtspiValueInterface {
-  AtspiValue* interface_;
-
+class AtspiValueInterface : public AtspiInterface<AtspiValue> {
  public:
-  AtspiValueInterface(AtspiValue* interface) : interface_(interface){};
-  AtspiValueInterface() : interface_(nullptr){};
-  ~AtspiValueInterface(){};
-
-  /**
-   * Tests whether the underlying AtspiValue pointer is the null pointer. An
-   * AtspiValueInterface with an null AtspiValue pointer will be created if the
-   * wrapped API returned a nullptr with no error codes.
-   * @ingroup atspi
-   */
-  bool isNull() const { return !interface_; }
+  using AtspiInterface::AtspiInterface;
+  using AtspiInterface::operator=;
 
   /**
    * Helper function to print commonly needed values associated with this
    * interface.
    * @ingroup atspi
    */
-  std::string toString() const;
+  std::string toString() const override;
 
   /**
    * Wraps

--- a/include/acacia/atspi/atspi_value_interface.h
+++ b/include/acacia/atspi/atspi_value_interface.h
@@ -18,8 +18,7 @@ namespace acacia {
  */
 class AtspiValueInterface : public AtspiInterface<AtspiValue> {
  public:
-  using AtspiInterface::AtspiInterface;
-  using AtspiInterface::operator=;
+  using AtspiInterface<AtspiValue>::AtspiInterface;
 
   /**
    * Helper function to print commonly needed values associated with this

--- a/lib/atspi/acacia_atspi.i
+++ b/lib/atspi/acacia_atspi.i
@@ -11,8 +11,6 @@
 #include <acacia/atspi/atspi_text_interface.h>
 #include <acacia/atspi/atspi_value_interface.h>
 #include <acacia/atspi/linux_utils.h>
-
-using namespace acacia;
 %}
 
 %include <std_except.i>
@@ -27,74 +25,101 @@ namespace std {
   %template(AtspiPairIntInt) pair<int, int>;
 };
 
-%catches(std::runtime_error) acacia::AtspiNode::getRoleName() const;
-%catches(std::runtime_error) acacia::AtspiNode::getName() const;
-%catches(std::runtime_error) acacia::AtspiNode::getDescription() const;
-%catches(std::runtime_error) acacia::AtspiNode::getAttributes() const;
-%catches(std::runtime_error) acacia::AtspiNode::getInterfaces() const;
-%catches(std::runtime_error) acacia::AtspiNode::getRelations() const;
-%catches(std::runtime_error) acacia::AtspiNode::getTargetForRelationAtIndex(int relation_index, int target_index) const;
-%catches(std::runtime_error) acacia::AtspiNode::getStates() const;
-%catches(std::runtime_error) acacia::AtspiNode::getChildCount() const;
-%catches(std::runtime_error) acacia::AtspiNode::getChildAtIndex(int index) const;
-%catches(std::runtime_error) acacia::AtspiNode::getChildren() const;
-%catches(std::runtime_error) acacia::AtspiNode::queryAction() const;
-%catches(std::runtime_error) acacia::AtspiNode::queryComponent() const;
-%catches(std::runtime_error) acacia::AtspiNode::queryDocument() const;
-%catches(std::runtime_error) acacia::AtspiNode::queryHyperlink() const;
-%catches(std::runtime_error) acacia::AtspiNode::queryTable() const;
-%catches(std::runtime_error) acacia::AtspiNode::queryTableCell() const;
-%catches(std::runtime_error) acacia::AtspiNode::queryText() const;
-%catches(std::runtime_error) acacia::AtspiNode::queryValue() const;
-
-%catches(std::runtime_error) acacia::AtspiActionInterface::isNull() const;
-%catches(std::runtime_error) acacia::AtspiActionInterface::toString() const;
-%catches(std::runtime_error) acacia::AtspiActionInterface::getNActions() const;
-%catches(std::runtime_error) acacia::AtspiActionInterface::getName(int index) const;
-%catches(std::runtime_error) acacia::AtspiActionInterface::getDescription(int index) const;
-
-%catches(std::runtime_error) acacia::AtspiComponentInterface::isNull() const;
-%catches(std::runtime_error) acacia::AtspiComponentInterface::toString() const;
-%catches(std::runtime_error) acacia::AtspiComponentInterface::getPosition() const;
-%catches(std::runtime_error) acacia::AtspiComponentInterface::getSize() const;
-
-%catches(std::runtime_error) acacia::AtspiDocumentInterface::isNull() const;
-%catches(std::runtime_error) acacia::AtspiDocumentInterface::toString() const;
-%catches(std::runtime_error) acacia::AtspiDocumentInterface::getDocumentAttributes() const;
-%catches(std::runtime_error) acacia::AtspiDocumentInterface::getLocale() const;
-
-%catches(std::runtime_error) acacia::AtspiHyperlinkInterface::isNull() const;
-%catches(std::runtime_error) acacia::AtspiHyperlinkInterface::toString() const;
-%catches(std::runtime_error) acacia::AtspiHyperlinkInterface::getStartIndex() const;
-%catches(std::runtime_error) acacia::AtspiHyperlinkInterface::getEndIndex() const;
-%catches(std::runtime_error) acacia::AtspiHyperlinkInterface::getURI(int index) const;
-
-%catches(std::runtime_error) acacia::AtspiTableInterface::isNull() const;
-%catches(std::runtime_error) acacia::AtspiTableInterface::toString() const;
-%catches(std::runtime_error) acacia::AtspiTableInterface::getNColumns() const;
-%catches(std::runtime_error) acacia::AtspiTableInterface::getNRows() const;
-
-%catches(std::runtime_error) acacia::AtspiTextInterface::isNull() const;
-%catches(std::runtime_error) acacia::AtspiTextInterface::toString() const;
-%catches(std::runtime_error) acacia::AtspiTextInterface::getCaretOffset() const;
-%catches(std::runtime_error) acacia::AtspiTextInterface::getCharacterCount() const;
-%catches(std::runtime_error) acacia::AtspiTextInterface::getText(int start_offset, int end_offset) const;
-
-%catches(std::runtime_error) acacia::AtspiTableCellInterface::isNull() const;
-%catches(std::runtime_error) acacia::AtspiTableCellInterface::toString() const;
-%catches(std::runtime_error) acacia::AtspiTableCellInterface::getPosition() const;
-%catches(std::runtime_error) acacia::AtspiTableCellInterface::getColumnIndex() const;
-%catches(std::runtime_error) acacia::AtspiTableCellInterface::getColumnSpan() const;
-%catches(std::runtime_error) acacia::AtspiTableCellInterface::getRowIndex() const;
-%catches(std::runtime_error) acacia::AtspiTableCellInterface::getRowSpan() const;
-
-%catches(std::runtime_error) acacia::AtspiValueInterface::isNull() const;
-%catches(std::runtime_error) acacia::AtspiValueInterface::toString() const;
-%catches(std::runtime_error) acacia::AtspiValueInterface::getCurrentValue() const;
-%catches(std::runtime_error) acacia::AtspiValueInterface::getMaximumValue() const;
-%catches(std::runtime_error) acacia::AtspiValueInterface::getMinimumValue() const;
-
 %include <acacia/atspi/atspi_interface.h>
+
+namespace acacia {
+  // Nested classes aren't supported, but it's a private implementation detail so
+  // we don't need it exposed to bindings anyway.
+  %warnfilter(325) AtspiInterface::Deleter;
+
+  %template(AtspiActionInterfaceTemplate) AtspiInterface<AtspiAction>;
+  %template(AtspiComponentInterfaceTemplate) AtspiInterface<AtspiComponent>;
+  %template(AtspiDocumentInterfaceTemplate) AtspiInterface<AtspiDocument>;
+  %template(AtspiHyperlinkInterfaceTemplate) AtspiInterface<AtspiHyperlink>;
+  %template(AtspiTableCellInterfaceTemplate) AtspiInterface<AtspiTableCell>;
+  %template(AtspiTableInterfaceTemplate) AtspiInterface<AtspiTable>;
+  %template(AtspiTextInterfaceTemplate) AtspiInterface<AtspiText>;
+  %template(AtspiValueInterfaceTemplate) AtspiInterface<AtspiValue>;
+
+  // SWIG complains about AtspiInterface not being an immediate base of these
+  // classes, even though it is in each instance.
+  %warnfilter(329) AtspiActionInterface;
+  %warnfilter(329) AtspiComponentInterface;
+  %warnfilter(329) AtspiDocumentInterface;
+  %warnfilter(329) AtspiHyperlinkInterface;
+  %warnfilter(329) AtspiTableCellInterface;
+  %warnfilter(329) AtspiTableInterface;
+  %warnfilter(329) AtspiTextInterface;
+  %warnfilter(329) AtspiValueInterface;
+
+  %catches(std::runtime_error) AtspiNode::getRoleName() const;
+  %catches(std::runtime_error) AtspiNode::getName() const;
+  %catches(std::runtime_error) AtspiNode::getDescription() const;
+  %catches(std::runtime_error) AtspiNode::getAttributes() const;
+  %catches(std::runtime_error) AtspiNode::getInterfaces() const;
+  %catches(std::runtime_error) AtspiNode::getRelations() const;
+  %catches(std::runtime_error) AtspiNode::getTargetForRelationAtIndex(int relation_index, int target_index) const;
+  %catches(std::runtime_error) AtspiNode::getStates() const;
+  %catches(std::runtime_error) AtspiNode::getChildCount() const;
+  %catches(std::runtime_error) AtspiNode::getChildAtIndex(int index) const;
+  %catches(std::runtime_error) AtspiNode::getChildren() const;
+  %catches(std::runtime_error) AtspiNode::queryAction() const;
+  %catches(std::runtime_error) AtspiNode::queryComponent() const;
+  %catches(std::runtime_error) AtspiNode::queryDocument() const;
+  %catches(std::runtime_error) AtspiNode::queryHyperlink() const;
+  %catches(std::runtime_error) AtspiNode::queryTable() const;
+  %catches(std::runtime_error) AtspiNode::queryTableCell() const;
+  %catches(std::runtime_error) AtspiNode::queryText() const;
+  %catches(std::runtime_error) AtspiNode::queryValue() const;
+
+  %catches(std::runtime_error) AtspiActionInterface::isNull() const;
+  %catches(std::runtime_error) AtspiActionInterface::toString() const;
+  %catches(std::runtime_error) AtspiActionInterface::getNActions() const;
+  %catches(std::runtime_error) AtspiActionInterface::getName(int index) const;
+  %catches(std::runtime_error) AtspiActionInterface::getDescription(int index) const;
+
+  %catches(std::runtime_error) AtspiComponentInterface::isNull() const;
+  %catches(std::runtime_error) AtspiComponentInterface::toString() const;
+  %catches(std::runtime_error) AtspiComponentInterface::getPosition() const;
+  %catches(std::runtime_error) AtspiComponentInterface::getSize() const;
+
+  %catches(std::runtime_error) AtspiDocumentInterface::isNull() const;
+  %catches(std::runtime_error) AtspiDocumentInterface::toString() const;
+  %catches(std::runtime_error) AtspiDocumentInterface::getDocumentAttributes() const;
+  %catches(std::runtime_error) AtspiDocumentInterface::getLocale() const;
+
+  %catches(std::runtime_error) AtspiHyperlinkInterface::isNull() const;
+  %catches(std::runtime_error) AtspiHyperlinkInterface::toString() const;
+  %catches(std::runtime_error) AtspiHyperlinkInterface::getStartIndex() const;
+  %catches(std::runtime_error) AtspiHyperlinkInterface::getEndIndex() const;
+  %catches(std::runtime_error) AtspiHyperlinkInterface::getURI(int index) const;
+
+  %catches(std::runtime_error) AtspiTableInterface::isNull() const;
+  %catches(std::runtime_error) AtspiTableInterface::toString() const;
+  %catches(std::runtime_error) AtspiTableInterface::getNColumns() const;
+  %catches(std::runtime_error) AtspiTableInterface::getNRows() const;
+
+  %catches(std::runtime_error) AtspiTextInterface::isNull() const;
+  %catches(std::runtime_error) AtspiTextInterface::toString() const;
+  %catches(std::runtime_error) AtspiTextInterface::getCaretOffset() const;
+  %catches(std::runtime_error) AtspiTextInterface::getCharacterCount() const;
+  %catches(std::runtime_error) AtspiTextInterface::getText(int start_offset, int end_offset) const;
+
+  %catches(std::runtime_error) AtspiTableCellInterface::isNull() const;
+  %catches(std::runtime_error) AtspiTableCellInterface::toString() const;
+  %catches(std::runtime_error) AtspiTableCellInterface::getPosition() const;
+  %catches(std::runtime_error) AtspiTableCellInterface::getColumnIndex() const;
+  %catches(std::runtime_error) AtspiTableCellInterface::getColumnSpan() const;
+  %catches(std::runtime_error) AtspiTableCellInterface::getRowIndex() const;
+  %catches(std::runtime_error) AtspiTableCellInterface::getRowSpan() const;
+
+  %catches(std::runtime_error) AtspiValueInterface::isNull() const;
+  %catches(std::runtime_error) AtspiValueInterface::toString() const;
+  %catches(std::runtime_error) AtspiValueInterface::getCurrentValue() const;
+  %catches(std::runtime_error) AtspiValueInterface::getMaximumValue() const;
+  %catches(std::runtime_error) AtspiValueInterface::getMinimumValue() const;
+}
+
 %include <acacia/atspi/atspi_action_interface.h>
 %include <acacia/atspi/atspi_component_interface.h>
 %include <acacia/atspi/atspi_document_interface.h>

--- a/lib/atspi/acacia_atspi.i
+++ b/lib/atspi/acacia_atspi.i
@@ -1,5 +1,6 @@
 %module acacia_atspi
 %{
+#include <acacia/atspi/atspi_interface.h>
 #include <acacia/atspi/atspi_action_interface.h>
 #include <acacia/atspi/atspi_component_interface.h>
 #include <acacia/atspi/atspi_document_interface.h>
@@ -93,6 +94,7 @@ namespace std {
 %catches(std::runtime_error) acacia::AtspiValueInterface::getMaximumValue() const;
 %catches(std::runtime_error) acacia::AtspiValueInterface::getMinimumValue() const;
 
+%include <acacia/atspi/atspi_interface.h>
 %include <acacia/atspi/atspi_action_interface.h>
 %include <acacia/atspi/atspi_component_interface.h>
 %include <acacia/atspi/atspi_document_interface.h>

--- a/lib/atspi/atspi_action_interface.cc
+++ b/lib/atspi/atspi_action_interface.cc
@@ -27,7 +27,7 @@ int AtspiActionInterface::getNActions() const {
     return 0;
 
   GError* error = nullptr;
-  int result = atspi_action_get_n_actions(interface_, &error);
+  int result = atspi_action_get_n_actions(interface_.get(), &error);
   if (error) {
     std::string err_msg = error->message;
     g_error_free(error);
@@ -41,7 +41,7 @@ std::string AtspiActionInterface::getName(int index) const {
     std::string();
 
   GError* error = nullptr;
-  char* name = atspi_action_get_name(interface_, index, &error);
+  char* name = atspi_action_get_name(interface_.get(), index, &error);
   if (error) {
     std::string err_msg = error->message;
     g_error_free(error);
@@ -57,7 +57,8 @@ std::string AtspiActionInterface::getDescription(int index) const {
     std::string();
 
   GError* error = nullptr;
-  char* description = atspi_action_get_description(interface_, index, &error);
+  char* description =
+      atspi_action_get_description(interface_.get(), index, &error);
   if (error) {
     std::string err_msg = error->message;
     g_error_free(error);

--- a/lib/atspi/atspi_component_interface.cc
+++ b/lib/atspi/atspi_component_interface.cc
@@ -29,8 +29,8 @@ std::pair<int, int> AtspiComponentInterface::getPosition() const {
   // the SCREEN coordinates. And some implementations (e.g. GTK4) don't
   // implement support for SCREEN coordinates even in X11.
   GError* error = nullptr;
-  AtspiPoint* position =
-      atspi_component_get_position(interface_, ATSPI_COORD_TYPE_WINDOW, &error);
+  AtspiPoint* position = atspi_component_get_position(
+      interface_.get(), ATSPI_COORD_TYPE_WINDOW, &error);
   if (error) {
     std::string err_msg = error->message;
     g_error_free(error);
@@ -46,7 +46,7 @@ std::pair<int, int> AtspiComponentInterface::getSize() const {
     return std::make_pair(0, 0);
 
   GError* error = nullptr;
-  AtspiPoint* size = atspi_component_get_size(interface_, &error);
+  AtspiPoint* size = atspi_component_get_size(interface_.get(), &error);
   if (error) {
     std::string err_msg = error->message;
     g_error_free(error);

--- a/lib/atspi/atspi_document_interface.cc
+++ b/lib/atspi/atspi_document_interface.cc
@@ -20,7 +20,7 @@ std::string AtspiDocumentInterface::toString() const {
 std::vector<std::string> AtspiDocumentInterface::getDocumentAttributes() const {
   GError* error = nullptr;
   GHashTable* attributes_hash =
-      atspi_document_get_document_attributes(interface_, &error);
+      atspi_document_get_document_attributes(interface_.get(), &error);
   std::vector<std::string> attributes;
   if (error) {
     std::string err_msg = error->message;
@@ -46,7 +46,7 @@ std::string AtspiDocumentInterface::getLocale() const {
     std::string();
 
   GError* error = nullptr;
-  char* locale = atspi_document_get_locale(interface_, &error);
+  char* locale = atspi_document_get_locale(interface_.get(), &error);
   if (error) {
     std::string err_msg = error->message;
     g_error_free(error);

--- a/lib/atspi/atspi_node.cc
+++ b/lib/atspi/atspi_node.cc
@@ -348,7 +348,7 @@ std::vector<AtspiNode> AtspiNode::getChildren() const {
     throw std::runtime_error(err_msg);
   }
 
-  result.reserve(child_count);
+  result.resize(child_count);
 
   for (auto i = 0; i < child_count; i++) {
     AtspiNode child_node = getChildAtIndex(i);

--- a/lib/atspi/atspi_node.cc
+++ b/lib/atspi/atspi_node.cc
@@ -6,6 +6,10 @@
 #include <stdexcept>
 #include <string>
 
+#include <glib.h>
+
+#include "scoped_g_lib_ptr.h"
+
 namespace {
 static const std::string StateTypeToString(const AtspiStateType state) {
   switch (state) {
@@ -156,119 +160,125 @@ static const std::string RelationTypeToString(
   }
 }
 
+void free_g_array_and_contents(GArray* array) {
+  g_array_free(array, TRUE);
+}
+
 }  // Namespace
 
 namespace acacia {
 
+using ScopedCStr = ScopedGLibPtr<char>;
+using ScopedGError = ScopedGTypePtr<GError, &g_error_free>;
+using ScopedGHashTable = ScopedGTypePtr<GHashTable, &g_hash_table_destroy>;
+using ScopedGArray = ScopedGTypePtr<GArray, &free_g_array_and_contents>;
+
 bool AtspiNode::isNull() const {
-  return accessible_ == NULL;
+  return accessible_.get() == NULL;
 }
 
 std::string AtspiNode::getRoleName() const {
-  GError* error = nullptr;
-  char* role_name = atspi_accessible_get_role_name(accessible_, &error);
-  if (error) {
+  ScopedGError error;
+  GError* error_ptr = error.get();
+  ScopedCStr role_name(
+      atspi_accessible_get_role_name(accessible_.get(), &error_ptr));
+  if (error_ptr) {
     std::string err_msg = error->message;
-    g_error_free(error);
     throw std::runtime_error(err_msg);
     return "";
   }
-  std::string result(role_name);
-  g_free(role_name);
-  return result;
+
+  return std::string(role_name.get());
 }
 
 std::string AtspiNode::getName() const {
-  GError* error = nullptr;
-  char* name = atspi_accessible_get_name(accessible_, &error);
-  if (error) {
+  ScopedGError error;
+  GError* error_ptr = error.get();
+  ScopedCStr name(atspi_accessible_get_name(accessible_.get(), &error_ptr));
+  if (error_ptr) {
     std::string err_msg = error->message;
-    g_error_free(error);
     throw std::runtime_error(err_msg);
   }
-  std::string result(name);
-  g_free(name);
-  return result;
+
+  return std::string(name.get());
 }
 
 std::string AtspiNode::getDescription() const {
-  GError* error = nullptr;
-  char* description = atspi_accessible_get_description(accessible_, &error);
-  if (error) {
+  ScopedGError error;
+  GError* error_ptr = error.get();
+  ScopedCStr description(
+      atspi_accessible_get_description(accessible_.get(), &error_ptr));
+  if (error_ptr) {
     std::string err_msg = error->message;
-    g_error_free(error);
     throw std::runtime_error(err_msg);
   }
-  std::string result(description);
-  g_free(description);
-  return result;
+
+  return std::string(description.get());
 }
 
 std::vector<std::string> AtspiNode::getAttributes() const {
-  GError* error = nullptr;
-  GHashTable* attributes_hash =
-      atspi_accessible_get_attributes(accessible_, &error);
+  ScopedGError error;
+  GError* error_ptr = error.get();
+  ScopedGHashTable attributes_hash(
+      atspi_accessible_get_attributes(accessible_.get(), &error_ptr));
   std::vector<std::string> attributes;
-  if (error) {
+  if (error_ptr) {
     std::string err_msg = error->message;
-    g_error_free(error);
     throw std::runtime_error(err_msg);
   }
 
   GHashTableIter iter;
   gpointer key, value;
-  g_hash_table_iter_init(&iter, attributes_hash);
+  g_hash_table_iter_init(&iter, attributes_hash.get());
   while (g_hash_table_iter_next(&iter, &key, &value)) {
     std::string attr_entry =
         static_cast<char*>(key) + std::string(":") + static_cast<char*>(value);
     attributes.push_back(attr_entry);
   }
 
-  g_hash_table_destroy(attributes_hash);
   return attributes;
 }
 
 std::vector<std::string> AtspiNode::getInterfaces() const {
-  GArray* interface_array = atspi_accessible_get_interfaces(accessible_);
+  ScopedGArray interface_array(
+      atspi_accessible_get_interfaces(accessible_.get()));
   std::vector<std::string> interfaces;
   for (unsigned i = 0; i < interface_array->len; i++) {
-    char* interface = g_array_index(interface_array, char*, i);
-    interfaces.push_back(interface);
-    g_free(interface);
+    ScopedCStr interface(g_array_index(interface_array, char*, i));
+    interfaces.push_back(interface.get());
   }
-  g_array_free(interface_array, TRUE);
   return interfaces;
 }
 
 std::vector<std::string> AtspiNode::getRelations() const {
-  GError* error = nullptr;
-  GArray* relation_array =
-      atspi_accessible_get_relation_set(accessible_, &error);
-  if (error) {
+  ScopedGError error;
+  GError* error_ptr = error.get();
+  ScopedGArray relation_array(
+      atspi_accessible_get_relation_set(accessible_.get(), &error_ptr));
+  if (error_ptr) {
     std::string err_msg = error->message;
-    g_error_free(error);
     throw std::runtime_error(err_msg);
   }
 
   std::vector<std::string> relations;
   for (unsigned i = 0; i < relation_array->len; i++) {
-    AtspiRelation* relation = g_array_index(relation_array, AtspiRelation*, i);
+    ScopedGObjectPtr<AtspiRelation> relation(
+        g_array_index(relation_array.get(), AtspiRelation*, i));
     AtspiRelationType relation_type =
-        atspi_relation_get_relation_type(relation);
+        atspi_relation_get_relation_type(relation.get());
     relations.push_back(RelationTypeToString(relation_type));
   }
-  g_array_free(relation_array, TRUE);
   return relations;
 }
 
 AtspiNode AtspiNode::getTargetForRelationAtIndex(int relation_index,
                                                  int target_index) const {
-  GError* error = nullptr;
-  GArray* relation_array =
-      atspi_accessible_get_relation_set(accessible_, &error);
-  if (error) {
+  ScopedGError error;
+  GError* error_ptr = error.get();
+  ScopedGArray relation_array(
+      atspi_accessible_get_relation_set(accessible_.get(), &error_ptr));
+  if (error_ptr) {
     std::string err_msg = error->message;
-    g_error_free(error);
     throw std::runtime_error(err_msg);
   }
 
@@ -276,54 +286,51 @@ AtspiNode AtspiNode::getTargetForRelationAtIndex(int relation_index,
     std::string msg = "Relation index " + std::to_string(relation_index) +
                       " exceeds relation count " +
                       std::to_string(relation_array->len);
-    g_array_free(relation_array, TRUE);
     throw std::runtime_error(msg);
   }
 
   AtspiRelation* relation =
-      g_array_index(relation_array, AtspiRelation*, relation_index);
+      g_array_index(relation_array.get(), AtspiRelation*, relation_index);
   AtspiAccessible* target = atspi_relation_get_target(relation, target_index);
   if (!target) {
-    g_array_free(relation_array, TRUE);
     throw std::runtime_error("Target is null");
   }
 
-  AtspiNode result = AtspiNode(target);
-  g_array_free(relation_array, TRUE);
-  return result;
+  return AtspiNode(target);
 }
 
 std::vector<std::string> AtspiNode::getStates() const {
-  AtspiStateSet* atspi_states = atspi_accessible_get_state_set(accessible_);
-  GArray* state_array = atspi_state_set_get_states(atspi_states);
+  ScopedGObjectPtr<AtspiStateSet> atspi_states(
+      atspi_accessible_get_state_set(accessible_.get()));
+  ScopedGArray state_array(atspi_state_set_get_states(atspi_states.get()));
+
   std::vector<std::string> states;
   for (unsigned i = 0; i < state_array->len; i++) {
     AtspiStateType state_type = g_array_index(state_array, AtspiStateType, i);
     states.push_back(StateTypeToString(state_type));
   }
-  g_array_free(state_array, TRUE);
-  g_object_unref(atspi_states);
+
   return states;
 }
 
 int AtspiNode::getChildCount() const {
-  GError* error = nullptr;
-  gint count = atspi_accessible_get_child_count(accessible_, &error);
-  if (error) {
+  ScopedGError error;
+  GError* error_ptr = error.get();
+  gint count = atspi_accessible_get_child_count(accessible_.get(), &error_ptr);
+  if (error_ptr) {
     std::string err_msg = error->message;
-    g_error_free(error);
     throw std::runtime_error(err_msg);
   }
   return (int)count;
 }
 
 AtspiNode AtspiNode::getChildAtIndex(int index) const {
-  GError* error = nullptr;
+  ScopedGError error;
+  GError* error_ptr = error.get();
   AtspiAccessible* child =
-      atspi_accessible_get_child_at_index(accessible_, index, &error);
-  if (error) {
+      atspi_accessible_get_child_at_index(accessible_.get(), index, &error_ptr);
+  if (error_ptr) {
     std::string err_msg = error->message;
-    g_error_free(error);
     throw std::runtime_error(err_msg);
   }
   return AtspiNode(child);
@@ -332,15 +339,16 @@ AtspiNode AtspiNode::getChildAtIndex(int index) const {
 std::vector<AtspiNode> AtspiNode::getChildren() const {
   std::vector<AtspiNode> result;
 
-  GError* error = nullptr;
-  gint child_count = atspi_accessible_get_child_count(accessible_, &error);
-  if (error) {
+  ScopedGError error;
+  GError* error_ptr = error.get();
+  gint child_count =
+      atspi_accessible_get_child_count(accessible_.get(), &error_ptr);
+  if (error_ptr) {
     std::string err_msg = error->message;
-    g_error_free(error);
     throw std::runtime_error(err_msg);
   }
 
-  result.resize(child_count);
+  result.reserve(child_count);
 
   for (auto i = 0; i < child_count; i++) {
     AtspiNode child_node = getChildAtIndex(i);
@@ -362,82 +370,80 @@ std::vector<AtspiNode> AtspiNode::getChildren() const {
 // interface. See https://gitlab.gnome.org/GNOME/at-spi2-core/-/issues/167 for
 // details.
 AtspiActionInterface AtspiNode::queryAction() const {
-  AtspiAction* iface = atspi_accessible_get_action_iface(accessible_);
-  if (iface) {
-    g_object_unref(iface);
-    return AtspiActionInterface(ATSPI_ACTION(accessible_));
+  ScopedGObjectPtr<AtspiAction> iface(
+      atspi_accessible_get_action_iface(accessible_.get()));
+  if (iface.get()) {
+    return AtspiActionInterface(iface.release());
   }
 
   return AtspiActionInterface();
 }
 
 AtspiComponentInterface AtspiNode::queryComponent() const {
-  AtspiComponent* iface = atspi_accessible_get_component_iface(accessible_);
-  if (iface) {
-    g_object_unref(iface);
-    return AtspiComponentInterface(ATSPI_COMPONENT(accessible_));
+  ScopedGObjectPtr<AtspiComponent> iface(
+      atspi_accessible_get_component_iface(accessible_.get()));
+  if (iface.get()) {
+    return AtspiComponentInterface(iface.release());
   }
 
   return AtspiComponentInterface();
 }
 
 AtspiDocumentInterface AtspiNode::queryDocument() const {
-  AtspiDocument* iface = atspi_accessible_get_document_iface(accessible_);
-  if (iface) {
-    g_object_unref(iface);
-    return AtspiDocumentInterface(ATSPI_DOCUMENT(accessible_));
+  ScopedGObjectPtr<AtspiDocument> iface(
+      atspi_accessible_get_document_iface(accessible_.get()));
+  if (iface.get()) {
+    return AtspiDocumentInterface(iface.release());
   }
 
   return AtspiDocumentInterface();
 }
 
 AtspiHyperlinkInterface AtspiNode::queryHyperlink() const {
-  // Unlike the other interfaces, `atspi_accessible_get_hyperlink` gives us a
-  // new hyperlink object that serves as the interface. Therefore we cannot
-  // free it until we're done with it. See also `atspi_hyperlink_interface.h`.
-  AtspiHyperlink* hyperlink = atspi_accessible_get_hyperlink(accessible_);
-  if (hyperlink) {
-    return AtspiHyperlinkInterface(hyperlink);
+  ScopedGObjectPtr<AtspiHyperlink> iface(
+      atspi_accessible_get_hyperlink(accessible_.get()));
+  if (iface.get()) {
+    return AtspiHyperlinkInterface(iface.release());
   }
 
   return AtspiHyperlinkInterface();
 }
 
 AtspiTableInterface AtspiNode::queryTable() const {
-  AtspiTable* iface = atspi_accessible_get_table_iface(accessible_);
-  if (iface) {
-    g_object_unref(iface);
-    return AtspiTableInterface(ATSPI_TABLE(accessible_));
+  ScopedGObjectPtr<AtspiTable> iface(
+      atspi_accessible_get_table_iface(accessible_.get()));
+  if (iface.get()) {
+    return AtspiTableInterface(iface.release());
   }
 
   return AtspiTableInterface();
 }
 
 AtspiTableCellInterface AtspiNode::queryTableCell() const {
-  AtspiTableCell* iface = atspi_accessible_get_table_cell(accessible_);
-  if (iface) {
-    g_object_unref(iface);
-    return AtspiTableCellInterface(ATSPI_TABLE_CELL(accessible_));
+  ScopedGObjectPtr<AtspiTableCell> iface(
+      atspi_accessible_get_table_cell(accessible_.get()));
+  if (iface.get()) {
+    return AtspiTableCellInterface(iface.release());
   }
 
   return AtspiTableCellInterface();
 }
 
 AtspiTextInterface AtspiNode::queryText() const {
-  AtspiText* iface = atspi_accessible_get_text_iface(accessible_);
-  if (iface) {
-    g_object_unref(iface);
-    return AtspiTextInterface(ATSPI_TEXT(accessible_));
+  ScopedGObjectPtr<AtspiText> iface(
+      atspi_accessible_get_text_iface(accessible_.get()));
+  if (iface.get()) {
+    return AtspiTextInterface(iface.release());
   }
 
   return AtspiTextInterface();
 }
 
 AtspiValueInterface AtspiNode::queryValue() const {
-  AtspiValue* iface = atspi_accessible_get_value_iface(accessible_);
-  if (iface) {
-    g_object_unref(iface);
-    return AtspiValueInterface(ATSPI_VALUE(accessible_));
+  ScopedGObjectPtr<AtspiValue> iface(
+      atspi_accessible_get_value_iface(accessible_.get()));
+  if (iface.get()) {
+    return AtspiValueInterface(iface.release());
   }
 
   return AtspiValueInterface();

--- a/lib/atspi/atspi_table_cell_interface.cc
+++ b/lib/atspi/atspi_table_cell_interface.cc
@@ -23,7 +23,7 @@ std::pair<int, int> AtspiTableCellInterface::getPosition() const {
 
   GError* error = nullptr;
   int row, column;
-  atspi_table_cell_get_position(interface_, &row, &column, &error);
+  atspi_table_cell_get_position(interface_.get(), &row, &column, &error);
   if (error) {
     std::string err_msg = error->message;
     g_error_free(error);
@@ -41,7 +41,7 @@ int AtspiTableCellInterface::getColumnSpan() const {
     return 0;
 
   GError* error = nullptr;
-  int result = atspi_table_cell_get_column_span(interface_, &error);
+  int result = atspi_table_cell_get_column_span(interface_.get(), &error);
   if (error) {
     std::string err_msg = error->message;
     g_error_free(error);
@@ -59,7 +59,7 @@ int AtspiTableCellInterface::getRowSpan() const {
     return 0;
 
   GError* error = nullptr;
-  int result = atspi_table_cell_get_row_span(interface_, &error);
+  int result = atspi_table_cell_get_row_span(interface_.get(), &error);
   if (error) {
     std::string err_msg = error->message;
     g_error_free(error);

--- a/lib/atspi/atspi_table_interface.cc
+++ b/lib/atspi/atspi_table_interface.cc
@@ -20,7 +20,7 @@ int AtspiTableInterface::getNColumns() const {
     return 0;
 
   GError* error = nullptr;
-  int result = atspi_table_get_n_columns(interface_, &error);
+  int result = atspi_table_get_n_columns(interface_.get(), &error);
   if (error) {
     std::string err_msg = error->message;
     g_error_free(error);
@@ -34,7 +34,7 @@ int AtspiTableInterface::getNRows() const {
     return 0;
 
   GError* error = nullptr;
-  int result = atspi_table_get_n_rows(interface_, &error);
+  int result = atspi_table_get_n_rows(interface_.get(), &error);
   if (error) {
     std::string err_msg = error->message;
     g_error_free(error);

--- a/lib/atspi/atspi_text_interface.cc
+++ b/lib/atspi/atspi_text_interface.cc
@@ -39,7 +39,7 @@ int AtspiTextInterface::getCaretOffset() const {
     return -1;
 
   GError* error = nullptr;
-  int result = atspi_text_get_caret_offset(interface_, &error);
+  int result = atspi_text_get_caret_offset(interface_.get(), &error);
   if (error) {
     std::string err_msg = error->message;
     g_error_free(error);
@@ -53,7 +53,7 @@ int AtspiTextInterface::getCharacterCount() const {
     return -1;
 
   GError* error = nullptr;
-  int result = atspi_text_get_character_count(interface_, &error);
+  int result = atspi_text_get_character_count(interface_.get(), &error);
   if (error) {
     std::string err_msg = error->message;
     g_error_free(error);
@@ -69,7 +69,7 @@ std::string AtspiTextInterface::getText(int start_offset,
 
   GError* error = nullptr;
   char* text =
-      atspi_text_get_text(interface_, start_offset, end_offset, &error);
+      atspi_text_get_text(interface_.get(), start_offset, end_offset, &error);
   if (error) {
     std::string err_msg = error->message;
     g_error_free(error);

--- a/lib/atspi/atspi_value_interface.cc
+++ b/lib/atspi/atspi_value_interface.cc
@@ -21,7 +21,7 @@ double AtspiValueInterface::getCurrentValue() const {
     return 0.0;
 
   GError* error = nullptr;
-  double result = atspi_value_get_current_value(interface_, &error);
+  double result = atspi_value_get_current_value(interface_.get(), &error);
   if (error) {
     std::string err_msg = error->message;
     g_error_free(error);
@@ -35,7 +35,7 @@ double AtspiValueInterface::getMaximumValue() const {
     return 0.0;
 
   GError* error = nullptr;
-  double result = atspi_value_get_maximum_value(interface_, &error);
+  double result = atspi_value_get_maximum_value(interface_.get(), &error);
   if (error) {
     std::string err_msg = error->message;
     g_error_free(error);
@@ -49,7 +49,7 @@ double AtspiValueInterface::getMinimumValue() const {
     return 0.0;
 
   GError* error = nullptr;
-  double result = atspi_value_get_minimum_value(interface_, &error);
+  double result = atspi_value_get_minimum_value(interface_.get(), &error);
   if (error) {
     std::string err_msg = error->message;
     g_error_free(error);

--- a/lib/atspi/linux_utils.cc
+++ b/lib/atspi/linux_utils.cc
@@ -5,84 +5,90 @@
 #include <acacia/atspi/linux_utils.h>
 
 #include "../utils.h"
+#include "scoped_g_lib_ptr.h"
 
 namespace acacia {
 
-AtspiNode findRootAtspiNodeForPID(const int pid) {
-  AtspiAccessible* desktop = atspi_get_desktop(0);
+using ScopedCStr = ScopedGLibPtr<char>;
+using ScopedGError = ScopedGTypePtr<GError, &g_error_free>;
 
-  GError* error = nullptr;
-  int child_count = atspi_accessible_get_child_count(desktop, &error);
-  if (error)
-    goto handle_gerror;
+AtspiNode findRootAtspiNodeForPID(const int pid) {
+  ScopedGObjectPtr<AtspiAccessible> desktop(atspi_get_desktop(0));
+
+  ScopedGError error;
+  GError* error_ptr = error.get();
+  int child_count = atspi_accessible_get_child_count(desktop.get(), &error_ptr);
+  if (error_ptr) {
+    std::string err_msg = error->message;
+    throw std::runtime_error(err_msg);
+  }
 
   for (int i = 0; i < child_count; i++) {
-    AtspiAccessible* child =
-        atspi_accessible_get_child_at_index(desktop, i, &error);
-    if (error)
-      goto handle_gerror;
-
-    pid_t application_pid = atspi_accessible_get_process_id(child, &error);
-    if (error)
-      goto handle_gerror;
-
-    if (pid == application_pid) {
-      return AtspiNode(child);
+    ScopedGObjectPtr<AtspiAccessible> child(
+        atspi_accessible_get_child_at_index(desktop.get(), i, &error_ptr));
+    if (error_ptr) {
+      std::string err_msg = error->message;
+      throw std::runtime_error(err_msg);
     }
 
-    g_object_unref(child);
+    pid_t application_pid =
+        atspi_accessible_get_process_id(child.get(), &error_ptr);
+    if (error_ptr) {
+      std::string err_msg = error->message;
+      throw std::runtime_error(err_msg);
+    }
+
+    if (pid == application_pid) {
+      return AtspiNode(child.release());
+    }
   }
   return AtspiNode();
-
-handle_gerror:
-  std::string err_msg = error->message;
-  g_error_free(error);
-  throw std::runtime_error(err_msg);
 }
 
 AtspiNode findRootAtspiNodeForName(const std::string& name, const int pid) {
-  AtspiAccessible* desktop = atspi_get_desktop(0);
+  ScopedGObjectPtr<AtspiAccessible> desktop(atspi_get_desktop(0));
   std::string lower_name = lower(name);
 
-  GError* error = nullptr;
-  int child_count = atspi_accessible_get_child_count(desktop, &error);
-  if (error)
-    goto handle_gerror;
+  ScopedGError error;
+  GError* error_ptr = error.get();
+  int child_count = atspi_accessible_get_child_count(desktop.get(), &error_ptr);
+  if (error_ptr) {
+    std::string err_msg = error->message;
+    throw std::runtime_error(err_msg);
+  }
 
   for (int i = 0; i < child_count; i++) {
-    AtspiAccessible* child =
-        atspi_accessible_get_child_at_index(desktop, i, &error);
-    if (error)
-      goto handle_gerror;
-
-    char* child_name = atspi_accessible_get_name(child, &error);
-    if (error)
-      goto handle_gerror;
-
-    std::string app_name = lower(child_name);
-    g_free(child_name);
-    if (app_name.find(lower_name) != std::string::npos) {
-      if (!pid) {
-        return AtspiNode(child);
-      }
-
-      pid_t application_pid = atspi_accessible_get_process_id(child, &error);
-      if (error)
-        goto handle_gerror;
-
-      if (pid == application_pid) {
-        return AtspiNode(child);
-      }
+    ScopedGObjectPtr<AtspiAccessible> child(
+        atspi_accessible_get_child_at_index(desktop.get(), i, &error_ptr));
+    if (error_ptr) {
+      std::string err_msg = error->message;
+      throw std::runtime_error(err_msg);
     }
 
-    g_object_unref(child);
+    ScopedCStr child_name(atspi_accessible_get_name(child.get(), &error_ptr));
+    if (error_ptr) {
+      std::string err_msg = error->message;
+      throw std::runtime_error(err_msg);
+    }
+
+    std::string app_name = lower(std::string(child_name.get()));
+    if (app_name.find(lower_name) != std::string::npos) {
+      if (!pid) {
+        return AtspiNode(child.release());
+      }
+
+      pid_t application_pid =
+          atspi_accessible_get_process_id(child.get(), &error_ptr);
+      if (error_ptr) {
+        std::string err_msg = error->message;
+        throw std::runtime_error(err_msg);
+      }
+
+      if (pid == application_pid) {
+        return AtspiNode(child.release());
+      }
+    }
   }
   return AtspiNode();
-
-handle_gerror:
-  std::string err_msg = error->message;
-  g_error_free(error);
-  throw std::runtime_error(err_msg);
 }
-
 }  // namespace acacia

--- a/lib/atspi/scoped_g_lib_ptr.h
+++ b/lib/atspi/scoped_g_lib_ptr.h
@@ -1,0 +1,89 @@
+#ifndef LIB_ATSPI_SCOPED_G_LIB_PTR_H_
+#define LIB_ATSPI_SCOPED_G_LIB_PTR_H_
+
+#include <iostream>
+#include <memory>
+
+#include <glib.h>
+
+namespace acacia {
+
+template <typename T>
+class ScopedGLibPtr {
+ public:
+  ScopedGLibPtr() = default;
+  explicit ScopedGLibPtr(T* ptr) : ptr_(ptr, Deleter()) {}
+
+  T* get() { return ptr_.get(); }
+  T* release() { return ptr_.release(); }
+
+ private:
+  class Deleter {
+   public:
+    void operator()(T* ptr) {
+      if (ptr == nullptr)
+        return;
+      g_free(ptr);
+    }
+  };
+
+  std::unique_ptr<T, Deleter> ptr_{nullptr};
+};
+
+template <typename T, void (*f)(T*)>
+class ScopedGTypePtr {
+ public:
+  ScopedGTypePtr() = default;
+  explicit ScopedGTypePtr(T* ptr) : ptr_(ptr, Deleter()) {}
+
+  T* get() { return ptr_.get(); }
+  T* release() { return ptr_.release(); }
+
+  T* operator->() { return ptr_.get(); }
+
+ private:
+  class Deleter {
+   public:
+    void operator()(T* ptr) {
+      if (ptr == nullptr)
+        return;
+
+      f(ptr);
+    }
+  };
+
+  std::unique_ptr<T, Deleter> ptr_{nullptr};
+};
+
+template <typename T>
+class ScopedGObjectPtr {
+ public:
+  ScopedGObjectPtr() = default;
+  explicit ScopedGObjectPtr(T* ptr) : ptr_(ptr, Deleter()) {}
+
+  ScopedGObjectPtr(const ScopedGObjectPtr& other) : ptr_(other.ptr_) {
+    if (ptr_.get())
+      g_object_ref(ptr_.get());
+  }
+
+  T* get() { return ptr_.get(); }
+  T* release() { return ptr_.release(); }
+
+  T* operator->() { return ptr_.get(); }
+
+ private:
+  class Deleter {
+   public:
+    void operator()(T* ptr) {
+      if (ptr == nullptr)
+        return;
+      g_object_unref(ptr);
+    }
+  };
+
+  std::unique_ptr<T, Deleter> ptr_{nullptr};
+};
+
+}  // namespace acacia
+
+#endif  // LIB_ATSPI_SCOPED_G_LIB_PTR_H_

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -5,7 +5,7 @@
 #include <vector>
 
 inline std::string lower(const std::string& str) {
-  std::string result = str;
+  std::string result(str);
   std::transform(result.begin(), result.end(), result.begin(),
                  [](unsigned char c) { return std::tolower(c); });
   return result;


### PR DESCRIPTION
Note: I did this as a way to understand how the Linux code works, and to play with the idea I'd used for a similar job in Mac code. If we feel like this isn't actually an improvement, I'm happy to let it be!

- Wrap each `AtspiNode`'s managed `AtspiAccessible` in a `std::shared_ptr`
- Add `AtspiInterface<T>` as a superclass for all the Atspi[Type]Interface classes.
   - Uses `std::shared_ptr` to manage references to wrapped objects, unref-ing when the `Interface` object goes out of scope
   - This means we don't need to worry about whether a particular `query_interface` method returns a reference to the existing object or a new object
- Add some convenience wrappers around `std::unique_ptr` to call the appropriate `free`/`unref` function, used for accessing data on `AtspiAccessible` interfaces