### PR TITLE
Fix dump_chromium_tree_linux workflow

### DIFF
--- a/.github/workflows/dump_chromium_tree_linux.yml
+++ b/.github/workflows/dump_chromium_tree_linux.yml
@@ -10,8 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Update apt
+        run: sudo apt update
       - name: Install System dependencies
-        run: sudo apt install -y at-spi2-core libatspi2.0-dev libnode-dev --fix-missing
+        run: sudo apt install -y at-spi2-core libatspi2.0-dev libnode-dev
       - name: Install Chromium
         run: sudo apt install -y chromium-browser
       - name: Launch D-Bus Session bus service

--- a/.github/workflows/dump_chromium_tree_linux.yml
+++ b/.github/workflows/dump_chromium_tree_linux.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Install System dependencies
-        run: sudo apt install -y at-spi2-core libatspi2.0-dev libnode-dev
+        run: sudo apt install -y at-spi2-core libatspi2.0-dev libnode-dev --fix-missing
       - name: Install Chromium
         run: sudo apt install -y chromium-browser
       - name: Launch D-Bus Session bus service


### PR DESCRIPTION
We were having issues because apt was out of date for some reason.